### PR TITLE
Adding service_healthy condition of blockchain_node to contract_deplo…

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -39,7 +39,8 @@ services:
     image: pointnetwork/pointnetwork_deployer:dev
     container_name: pointnetwork_contract_deployer
     depends_on:
-      - blockchain_node
+      blockchain_node:
+        condition: service_healthy
     deploy:
       restart_policy:
         condition: none


### PR DESCRIPTION
…yer node.

It seems that the only the service_healthy condition was missing in contract_deployer node. I tested several times and always worked the deployer runs only after the blockchain_node is running. Also tested just run the contract_deployer node and it waits blockchain_node to start properly. 
