### PR TITLE
Warinig when a zapp has missing dependencies

### DIFF
--- a/scripts/deploy-sites.sh
+++ b/scripts/deploy-sites.sh
@@ -4,6 +4,11 @@
 # Run this script from within the project root folder like so:
 # ./scripts/deploy-sites.sh
 
+# Text color for error and warning messages
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
 if [ "$2" == "--contracts" ]; then
     DEPLOY_CONTRACTS="--contracts"
 else
@@ -31,16 +36,16 @@ do
     continue
   fi
   echo
+  if [ -f ${SITE}/package.json ] && [ ! -d ${SITE}/node_modules ]; then
+    echo -e "${YELLOW}WARNING${NC}: ZApp has a package.json file but node_modules folder is missing. ${YELLOW}Did you forget to install Zapp dependencies?${NC}"
+  fi
+
+  echo
   echo "DEPLOYING: ${SITE}"
   echo
 
   echo "./point deploy $SITE --datadir $DATADIR $DEPLOY_CONTRACTS -v"
   ./point deploy $SITE --datadir $DATADIR $DEPLOY_CONTRACTS -v
-
-  echo
-  if [ -f ${SITE}/package.json ] && [ ! -d ${SITE}/node_modules ]; then 
-    echo "WARNING: ZApp has a package.json file but node_modules folder is missing. Did you forget to install Zapp dependencies?"
-  fi
 
   echo
   echo "FINISHED: ${SITE}"

--- a/scripts/deploy-sites.sh
+++ b/scripts/deploy-sites.sh
@@ -38,6 +38,11 @@ do
   ./point deploy $SITE --datadir $DATADIR $DEPLOY_CONTRACTS -v
 
   echo
+  if [ -f ${SITE}/package.json ] && [ ! -d ${SITE}/node_modules ]; then 
+    echo "WARNING: ZApp has a package.json file but node_modules folder is missing. Did you forget to install Zapp dependencies?"
+  fi
+
+  echo
   echo "FINISHED: ${SITE}"
   echo
 done


### PR DESCRIPTION
Adding a warning when a Zapp has a package.json and not the folder node_modules. In this case the zapp developer should run npm install to install the dependencies before deploy the site.