### PR TITLE
Remove DEV_ZAPP_HOST to make deployment easier

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,6 +1,3 @@
-# Set DEV_ZAPP_HOST to the host name like pointsocial.z
-DEV_ZAPP_HOST=
-
 # Remaining env keys below can remain as they are
 POINT_NODE_VERSION=v1.0.28
 BLOCKCHAIN_NETWORK_ID=256

--- a/client/proxy/index.js
+++ b/client/proxy/index.js
@@ -251,9 +251,9 @@ class ZProxy {
                 let localPath = 'internal/explorer.z/public'; // hardcode to render explorer.z
                 rendered = await this.processLocalRequest(host, localPath, request, response, parsedUrl);
                 contentType = response._contentType;
-            } else if (host === process.env.DEV_ZAPP_HOST) {
-                // when DEV_ZAPP_HOST is set this site will be loaded directly from the local system - useful for Zapp developers :)
-                let localPath = `example/${process.env.DEV_ZAPP_HOST}/public`; // hardcode to render the zapp host stated in DEV_ZAPP_HOST local env
+            } else if (process.env.MODE === 'e2e') {
+                // when MODE=e2e is set this site will be loaded directly from the local system - useful for Zapp developers :)
+                let localPath = `example/${host}/public`; // hardcode to render the zapp host
                 rendered = await this.processLocalRequest(host, localPath, request, response, parsedUrl);
                 contentType = response._contentType;
             }  else {

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -126,8 +126,8 @@ services:
       - ./deployspace:/app/deployspace:ro
     environment:
       DATADIR: /data
+      MODE: e2e
       DB_ENV: pointnode2
-      DEV_ZAPP_HOST: $DEV_ZAPP_HOST
       BLOCKCHAIN_URL: $BLOCKCHAIN_URL
       BLOCKCHAIN_NETWORK_ID: $BLOCKCHAIN_NETWORK_ID
       BLOCKCHAIN_HOST: $BLOCKCHAIN_HOST


### PR DESCRIPTION
Removed the `DEV_ZAPP_HOST` env var as a dependency so that `e2e` is more seamless for Zapp deployment and testing. Now there's no need to restart the environment while switching between Zapps and can now test multiple Zapps on the same go.