### PR TITLE
Include last deployment timestamps to Point Explorer Identity meta data page

### DIFF
--- a/client/zweb/renderer/index.js
+++ b/client/zweb/renderer/index.js
@@ -123,11 +123,30 @@ class Renderer {
                 return await this.renderer.ctx.web3bridge.sendToContract(host.replace('.z', ''), contractName, methodName, params);
             },
             contract_events: async function(host, contractName, event, filter = {}) {
+
+                //delete keys property inserted by twig
+                if(filter.hasOwnProperty('_keys'))
+                    delete filter['_keys'];
+
                 const options = { filter, fromBlock: 1, toBlock: 'latest' };
                 const events =  await this.renderer.ctx.web3bridge.getPastEvents(host.replace('.z', ''), contractName, event, options);
-                // for(let ev of events) console.log(ev, ev.raw);
+                let eventData = []
+                for(let ev of events) {
+                    //console.log(ev, ev.raw);
+                    const eventTimestamp = await this.renderer.ctx.web3bridge.getBlockTimestamp(ev.blockNumber);
 
-                const eventData = events.map((event) => (({ returnValues }) => ({ data: returnValues }))(event));
+                    eventData.push({
+                        data: ev.returnValues,
+                        timestamp: eventTimestamp
+                    })
+                }
+
+                //filter non-indexed properties from return value for convenience
+                if (filter != {}){
+                    for(let k in filter)
+                        eventData  = eventData.filter(e => e.data[k] == filter[k])
+                }
+                
                 return eventData;
             },
             default_wallet_address: async function(id, passcode) {

--- a/internal/explorer.z/public/identity.zhtml
+++ b/internal/explorer.z/public/identity.zhtml
@@ -31,7 +31,8 @@
 
 <table class="table table-bordered table-primary table-striped table-hover table-responsive">
     {% set ikvKeys = contract_list('@', 'Identity', 'ikvList', [request.handle]) %}
-
+    {% set events = contract_events('@', 'Identity', 'IKVSet', {identity: request.handle})  %}
+    
     {% for k in ikvKeys %}
         {% set v = identity_ikv_get(request.handle, k) %}
 
@@ -46,6 +47,15 @@
                 {% else %}
                     {{ v }}
                 {% endif %}
+            </td>
+            <td>
+                {% set timestamp_array = [] %}
+                {% for ev in events %}
+                    {% if ev.data.key == k and ev.data.value == v %}
+                        {% set timestamp_array = timestamp_array|merge([ev.timestamp]) %}
+                    {% endif %}
+                {% endfor %}
+                {{timestamp_array|sort|reverse|first|date}}
             </td>
         </tr>
     {% else %}

--- a/network/web3bridge.js
+++ b/network/web3bridge.js
@@ -187,6 +187,10 @@ class Web3Bridge {
         return await contract.getPastEvents(event, options);
     }
 
+    async getBlockTimestamp(blockNumber){
+        return (await this.web3.eth.getBlock(blockNumber)).timestamp;
+    }
+
     async subscribeContractEvent(target, contractName, event, onEvent, onStart, options={}) {
         const contract = await this.loadWebsiteContract(target, contractName);
 


### PR DESCRIPTION
Getting the IKVSet events of identity contract for the specific ZApp and matching with ikv elements in identity page. After that,  sorting and getting the last one. The timestamp is the block timestamp which the key value pair where inserted. 