### PR TITLE
Fix/Likes on pointsocial.z posts need to be counted unique by identity

### DIFF
--- a/example/pointsocial.z/contracts/PointSocial.sol
+++ b/example/pointsocial.z/contracts/PointSocial.sol
@@ -120,10 +120,30 @@ contract PointSocial {
     }
 
     // Likes data functions
-    function addLikeToPost(uint256 postId) public {
-        Like[] memory _likesOnPost = likesByPost[postId];
+    function addLikeToPost(uint256 postId) public returns(bool) {
+        // Get the post and likes for the postId from the mapping
+        Like[] storage _likesOnPost = likesByPost[postId];
+        Post storage _post = postById[postId];
+
+        uint256 _removeIndex;
+        bool _isLiked = false;
+
+        // Check if msg.sender has already liked
         for (uint256 i = 0; i < _likesOnPost.length; i++) {
-            require(_likesOnPost[i].from != msg.sender,"You have already liked the post");
+            if(_likesOnPost[i].from == msg.sender) {
+                _isLiked = true;
+                _removeIndex = i;
+                break;
+            }
+        }
+        // If yes, then we remove that like and decrement the likesCount for the post
+        if(_isLiked) {
+            for (uint256 i = _removeIndex; i < _likesOnPost.length - 1; i++) {
+                _likesOnPost[i] = _likesOnPost[i+1];
+            }
+            _likesOnPost.pop();
+            _post.likesCount--;
+            return false;
         }
 
         _likeIds.increment();
@@ -131,6 +151,7 @@ contract PointSocial {
         Like memory _like = Like(newLikeId, msg.sender, block.timestamp);
         _likesOnPost.push(_like);
         postById[postId].likesCount += 1;
+        return true;
     }
 
     function add(

--- a/example/pointsocial.z/contracts/PointSocial.sol
+++ b/example/pointsocial.z/contracts/PointSocial.sol
@@ -121,10 +121,15 @@ contract PointSocial {
 
     // Likes data functions
     function addLikeToPost(uint256 postId) public {
+        Like[] memory _likesOnPost = likesByPost[postId];
+        for (uint256 i = 0; i < _likesOnPost.length; i++) {
+            require(_likesOnPost[i].from != msg.sender,"You have already liked the post");
+        }
+
         _likeIds.increment();
         uint256 newLikeId = _likeIds.current();
         Like memory _like = Like(newLikeId, msg.sender, block.timestamp);
-        likesByPost[postId].push(_like);
+        _likesOnPost.push(_like);
         postById[postId].likesCount += 1;
     }
 


### PR DESCRIPTION
This PR fixes a bug where a user was previously able to add multiple likes to a post from the same identity. The solution was to add a check for that in the Solidity Contract and unlike the post if like button is pressed again.

[Trello card](https://trello.com/c/96ggvlgH/41-likes-on-pointsocialz-posts-need-to-be-counted-unique-by-identity)