### PR TITLE
Removing read only from volumes of deployment folders

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -122,7 +122,7 @@ services:
       - ./resources/demo-docker/config.test2.json:/nodeConfig.json:ro
       - ./resources/demo-docker/mnemonic-website_owner.json:/data/keystore/key.json
       - ./resources/sequelizeConfig.docker.e2e.json:/app/resources/sequelizeConfig.json:ro
-      - ./example:/app/example:ro
+      - ./example:/app/example
       - ./deployspace:/app/deployspace:ro
     environment:
       DATADIR: /data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - point_contracts:/app/truffle/build/contracts
       - point_node_data:/data
       - $POINT_KEYSTORE:/data/keystore
-      - $POINT_DEPLOYSPACE:/app/deployspace:ro
+      - $POINT_DEPLOYSPACE:/app/deployspace
     ports:
       - '8666:8666'
       - '2468:2468'


### PR DESCRIPTION
When a Zapp is deployed, point_node container downloads the files from arweave to run it locally. However, in website_owner container as the examples folder is mounted as ready only in e2e config, arweave cannot write to this folder. The same could be happening in YNet deployspace folder in the machine that deployed the zapp. 

This is the simpler solution that I found to solve this problem. However, we need to consider the potential side effects of setting the volumes as writable. One other problem with read only container for examples or deployspace folder is to run npm install. The node_modules folder is system dependent and in e2e config we are only able to run npm install from outside of the container, what possibly may lead to system incompatibilities in the dependencies.  