### PR TITLE
Enforcing original_path to a temp one

### DIFF
--- a/client/storage/index-arweave.js
+++ b/client/storage/index-arweave.js
@@ -100,7 +100,7 @@ class StorageArweave {
 
         // Setting `originalPath` to the `chunkify`ed version of `file`,
         // instead of the path where we find the original file source.
-        // todo: should we?
+        // This is necessary because if not done it brokes the ZApps after deployment.
         const original_path = path.join(this.getCacheDir(), 'chunk_'+throwAwayFile.id);
 
         const file = (await File.findOrCreate({ where: { id: throwAwayFile.id }, defaults: { original_path } })) [0];
@@ -109,6 +109,7 @@ class StorageArweave {
         file.redundancy = Math.max(parseInt(file.redundancy)||0, parseInt(redundancy)||0);
         file.expires = Math.max(parseInt(file.expires)||0, parseInt(expires)||0);
         file.autorenew = (!!file.autorenew) ? !!file.autorenew : !!autorenew;
+        file.original_path = original_path;
         await file.save();
         await file.reconsiderUploadingStatus();
 

--- a/client/storage/index.js
+++ b/client/storage/index.js
@@ -55,7 +55,7 @@ class Storage {
 
         // Setting `originalPath` to the `chunkify`ed version of `file`,
         // instead of the path where we find the original file source.
-        // todo: should we?
+        // This is necessary because if not done it brokes the ZApps after deployment.
         const original_path = path.join(this.getCacheDir(), 'chunk_'+throwAwayFile.id);
 
         const file = (await File.findOrCreate({ where: { id: throwAwayFile.id }, defaults: { original_path } })) [0];
@@ -64,6 +64,7 @@ class Storage {
         file.redundancy = Math.max(parseInt(file.redundancy)||0, parseInt(redundancy)||0);
         file.expires = Math.max(parseInt(file.expires)||0, parseInt(expires)||0);
         file.autorenew = (!!file.autorenew) ? !!file.autorenew : !!autorenew;
+        file.original_path = original_path;
         await file.save();
         await file.reconsiderUploadingStatus();
 


### PR DESCRIPTION
When uploading a file if the file was already created the original_path is not set to a temp one remaining the original filesystem path. This was crashing the ZApp access right after the deployment since arweave try to write the downloaded file to a path that does not exists or is not writable.