### PR TITLE
Fix build-e2e script

### DIFF
--- a/.bash_alias
+++ b/.bash_alias
@@ -7,11 +7,14 @@ alias point-browser-docker-2="web-ext run --firefox-profile=website_owner_docker
 alias point-browser-docker-3="web-ext run --firefox-profile=website_visitor_docker --keep-profile-changes --source-dir dist/prod --url https://point/"
 
 build-e2e() {
-    docker image inspect pointnetwork/pointnetwork_node:`git branch --show-current` > /dev/null 2>&1;
+    local image=$(git branch --show-current | sed 's/[^a-zA-Z0-9]/-/g');
+
+    docker image inspect pointnetwork/pointnetwork_node:$image > /dev/null 2>&1;
 
     if [[ $? != 0 ]] || [ "$1" == "--force" ]; then 
-        docker build -t "pointnetwork/pointnetwork_node:`git branch --show-current`" .; 
-        perl -i -pe"s/POINT_NODE_VERSION=.*/POINT_NODE_VERSION=`git branch --show-current`/" .env.e2e;
+        echo "Building image: pointnetwork/pointnetwork_node:$image";
+        docker build -t "pointnetwork/pointnetwork_node:$image" .; 
+        perl -i -pe"s/POINT_NODE_VERSION=.*/POINT_NODE_VERSION=$image/" .env.e2e;
     else
         echo "Docker Image for current branch exists. To rebuild the image run 'build-e2e --force'";
     fi;

--- a/.bash_alias
+++ b/.bash_alias
@@ -7,7 +7,8 @@ alias point-browser-docker-2="web-ext run --firefox-profile=website_owner_docker
 alias point-browser-docker-3="web-ext run --firefox-profile=website_visitor_docker --keep-profile-changes --source-dir dist/prod --url https://point/"
 
 build-e2e() {
-    local image=$(git branch --show-current | sed 's/[^a-zA-Z0-9]/-/g');
+    local branch=$(git branch --show-current);
+    local image=$(echo "${branch//+([^a-zA-z0-9])/-}");
 
     docker image inspect pointnetwork/pointnetwork_node:$image > /dev/null 2>&1;
 

--- a/.bash_alias
+++ b/.bash_alias
@@ -7,14 +7,13 @@ alias point-browser-docker-2="web-ext run --firefox-profile=website_owner_docker
 alias point-browser-docker-3="web-ext run --firefox-profile=website_visitor_docker --keep-profile-changes --source-dir dist/prod --url https://point/"
 
 build-e2e() {
-    local branch=$(git branch --show-current);
-    local image=$(echo "${branch//+([^a-zA-z0-9])/-}");
+    local image=$(git branch --show-current | sed 's/[^a-zA-Z0-9]/-/g');
 
     docker image inspect pointnetwork/pointnetwork_node:$image > /dev/null 2>&1;
 
-    if [[ $? != 0 ]] || [ "$1" == "--force" ]; then 
+    if [[ $? != 0 ]] || [ "$1" == "--force" ]; then
         echo "Building image: pointnetwork/pointnetwork_node:$image";
-        docker build -t "pointnetwork/pointnetwork_node:$image" .; 
+        docker build -t "pointnetwork/pointnetwork_node:$image" .;
         perl -i -pe"s/POINT_NODE_VERSION=.*/POINT_NODE_VERSION=$image/" .env.e2e;
     else
         echo "Docker Image for current branch exists. To rebuild the image run 'build-e2e --force'";


### PR DESCRIPTION
Fixes the issue with tagging when we have `/` in our branch. Great StackOverflow resource [here](https://stackoverflow.com/questions/62905914/turning-a-git-branch-name-into-a-valid-docker-image-tag) for reference.