### PR TITLE
Add util to resolve path when ~ is used

### DIFF
--- a/src/core/log.js
+++ b/src/core/log.js
@@ -5,6 +5,7 @@ const udpTransport = require('pino-udp');
 const {multistream} = require('pino-multi-stream');
 const ecsFormat = require('@elastic/ecs-pino-format');
 const config = require('config');
+const {resolveHome} = require('../core/utils');
 
 const datadir = config.get('datadir');
 const {level, enabled, sendLogs, sendLogsTo} = config.get('log');
@@ -18,7 +19,7 @@ if (sendLogs && sendLogsTo) {
 
 streams.push(
     {level: options.level, stream: pino({prettyPrint: {colorize: true}})[pino.symbols.streamSym]},
-    {level: options.level, stream: createWriteStream(path.resolve(path.join(datadir, 'point.log')))}
+    {level: options.level, stream: createWriteStream(path.resolve(path.join(resolveHome(datadir), 'point.log')))}
 );
 
 module.exports = Object.assign(pino(options, multistream(streams)), {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -3,6 +3,7 @@ const mkdirp = require('mkdirp');
 const ethUtil = require('ethereumjs-util');
 const {promises: fs} = require('fs');
 const kadUtils = require('@pointnetwork/kadence').utils;
+const os = require('os');
 
 const utils = {
     makeSurePathExists: function (path) {
@@ -167,7 +168,15 @@ const utils = {
                 throw e;
             }
         }
+    },
+
+    resolveHome: (filepath) => {
+        if (filepath[0] === '~') {
+            return path.join(process.env.HOME || os.homedir(), filepath.slice(1));
+        }
+        return filepath;
     }
+
 };
 
 utils.merkle = require('./merkle-utils');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import {existsSync, writeFileSync} from 'fs';
 import lockfile from 'proper-lockfile';
 import disclaimer from './disclaimer';
+import { resolveHome } from './core/utils';
 
 const program: any = new Command();
 
@@ -136,7 +137,9 @@ Model.setCtx(ctx);
 
 // This is just a dummy file: proper-lockfile handles the lockfile creation,
 // but it's intended to lock some existing file
-const lockfilePath = path.join(config.get('datadir'), 'point');
+
+const lockfilePath = path.join(resolveHome(config.get('datadir')), 'point');
+
 if (!existsSync(lockfilePath)) {
     writeFileSync(lockfilePath, 'point');
 }


### PR DESCRIPTION
When ~ is provided as the datadir path.resolves concatenates it in the absolute path creating a bug:

suppose:
```
datadir = '~/a/b'
```

it resolves to:
```
/root/somedirectory/~/a/b
```

It should resolve to:
```
/user/home_directory/a/b

```