### PR TITLE
removing arlocal workaround

### DIFF
--- a/docker-compose.zappdev.yaml
+++ b/docker-compose.zappdev.yaml
@@ -17,7 +17,7 @@ services:
           service: contract_deployer
     volumes:
       - shared_contracts_zappdev:/build:rw
-    
+
   point_node:
     extends:
       file: docker-compose.base.yaml
@@ -44,7 +44,7 @@ services:
       - '24681:2468'
     environment:
       NODE_CONFIG_ENV: zappdev
-  
+
   website_visitor:
     extends:
       file: docker-compose.base.yaml
@@ -75,7 +75,7 @@ services:
       DATADIR: /data
 
   arlocal:
-    image: textury/arlocal
+    image: textury/arlocal:v1.1.21
     container_name: arlocal
     command: node bin/index.js --persist=true
     ports:

--- a/src/client/storage/index-arlocal.js
+++ b/src/client/storage/index-arlocal.js
@@ -115,17 +115,8 @@ const getChunk = async (chunkId, encoding = 'utf8', useCache = true) => {
             const txid = edge.node.id;
             log.debug({chunkId, txid}, 'Downloading data from arweave');
 
-            // TODO: Remove the axios hack below when this bug of arlocal is resolved
-            // https://github.com/textury/arlocal/issues/63
-            const data = (await axios.get('http://' +  config.get('storage.arweave_host') +
-                ':' + config.get('storage.arweave_port') + '/tx/' +  txid + '/data')).data;
-            const buf = Buffer.from(data, 'base64');
-
-            /*
-            // NOTE: above code can be replaced with below when mentioned arlocal bug is resolved
             const data = await arweave.transactions.getData(txid, {decode: true});
             const buf = Buffer.from(data);
-            */
 
             log.debug({chunkId, txid}, 'Successfully downloaded data from arweave');
 


### PR DESCRIPTION
Arlocal presented a bug for download chunks, [this one](https://github.com/textury/arlocal/issues/63). We bypassed the bug with a workarount to fetch chunks in another way. Now arlocal bug is fixed and we were able to remove the workaround. To test this PR is necessary to remove the image textury/arlocal and download it again from docker hub.