### PR TITLE
Improve build of executables pipeline

### DIFF
--- a/.github/workflows/pkg.yaml
+++ b/.github/workflows/pkg.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Create package
       run: npm run pkg
     - name: Compress pkg
-      run: gzip -r bin/
+      run: ./scripts/package-executables.sh
     - name: Get the Source Tag
       id: get_source_tag
       run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
@@ -68,8 +68,8 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./bin/pointnetwork-linux.gz
-        asset_name: pointnetwork-linux-${{ steps.get_source_tag.outputs.SOURCE_TAG }}.gz
+        asset_path: ./bin/point-linux.tar.gz
+        asset_name: point-linux-${{ steps.get_source_tag.outputs.SOURCE_TAG }}.tar.gz
         asset_content_type: application/gzip
     - name: upload windows artefact
       uses: actions/upload-release-asset@v1
@@ -77,8 +77,8 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./bin/pointnetwork-win.exe.gz
-        asset_name: pointnetwork-win-${{ steps.get_source_tag.outputs.SOURCE_TAG }}.gz
+        asset_path: ./bin/point-win.tar.gz
+        asset_name: point-win-${{ steps.get_source_tag.outputs.SOURCE_TAG }}.tar.gz
         asset_content_type: application/gzip
     - name: upload macos artefact
       uses: actions/upload-release-asset@v1
@@ -86,6 +86,6 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./bin/pointnetwork-macos.gz
-        asset_name: pointnetwork-macos-${{ steps.get_source_tag.outputs.SOURCE_TAG }}.gz
+        asset_path: ./bin/point-macos.tar.gz
+        asset_name: point-macos-${{ steps.get_source_tag.outputs.SOURCE_TAG }}.tar.gz
         asset_content_type: application/gzip

--- a/scripts/package-executables.sh
+++ b/scripts/package-executables.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script will rename, add execution permissions and compress point executables.
+
+for FILE in ./bin/*; do
+  chmod +x $FILE
+  tmp=${FILE#*-};
+  PLATFORM=${tmp%.*}
+  EXTENSION=${tmp#*\.};
+  mkdir ./bin/$PLATFORM;
+  if [ "$tmp" == "$EXTENSION" ]; then
+    mv $FILE ./bin/$PLATFORM/point
+  else
+    mv $FILE ./bin/$PLATFORM/point.$EXTENSION
+  fi
+  tar -czvf ./bin/point-$PLATFORM.tar.gz ./bin/$PLATFORM
+  rm -rf ./bin/$PLATFORM
+done


### PR DESCRIPTION
Add executable permissions.
Rename all executables to point
Use tar to compress the file in order to keep permissions and file name