### PR TITLE
PN-114 Remove support for https://web3.test.

### DIFF
--- a/src/api/controllers/BlockchainController.ts
+++ b/src/api/controllers/BlockchainController.ts
@@ -8,9 +8,7 @@ export type RPCRequestBody = {
     params?: unknown[];
 };
 
-type HandlerFunc = (
-    req: FastifyRequest
-) => Promise<{
+type HandlerFunc = (req: FastifyRequest) => Promise<{
     status: number;
     result: unknown;
 }>;
@@ -92,6 +90,7 @@ class BlockchainController extends PointSDKController {
         const permissionHandler = permissionHandlers[method];
         if (permissionHandler) {
             const {status, result} = await permissionHandler(this.req);
+            this.reply.status(status);
             return this._status(status)._response(result);
         }
 
@@ -99,6 +98,7 @@ class BlockchainController extends PointSDKController {
         const specialHandler = specialHandlers[method];
         if (specialHandler) {
             const {status, result} = await specialHandler(this.req);
+            this.reply.status(status);
             return this._status(status)._response(result);
         }
 

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -219,25 +219,6 @@ const attachCommonHandler = (server: FastifyInstance, ctx: any) => {
                         res.header('content-type', contentType);
                         return file;
                     }
-                } else if (req.method.toUpperCase() === 'POST' && host === 'web3.test') {
-                    const BASE = `http://${config.get('api.address')}:${config.get('api.port')}`;
-                    const URL = `${BASE}/v1/api/blockchain`;
-
-                    const headers: Record<string, string> = {'Content-Type': 'application/json'};
-                    if (origin) {
-                        headers.origin = origin;
-                    }
-
-                    try {
-                        const resp = await axios.post(URL, req.body, {headers});
-                        res.status(resp.data.status).send(resp.data);
-                    } catch (err) {
-                        if (err.response) {
-                            res.status(err.response.status).send(err.response.data);
-                        } else {
-                            res.status(500).send(err);
-                        }
-                    }
                 } else {
                     res.status(404).send('Not Found');
                 }


### PR DESCRIPTION
To keep things simple and avoid cross-origin requests, instead of Point SDK making requests to `https://web3.test`, it will make them to `${host}/v1/api/blockchain`.

This means that the Point Node proxy does not need any special logic to support the `https://web3.test` host.