### PR TITLE
PN-120 Handle RPC requests through WS and REST

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -5,6 +5,7 @@ api:
   address: 127.0.0.1
   port: 2468
   csrf_enabled: false
+  sdk_auth_key: "POINTSDK_TOKEN"
 db:
   define:
     underscored: true
@@ -71,3 +72,5 @@ network:
   hardcode_default_provider: "0x3C903ADdcC954B318A5077D0f7bce44a7b9c95B1"
 payments:
   token_address: "0xbf9be54Df2001E6Bd044cED0E508d936A9d38b1D"
+rpc:
+  send_transaction_timeout_secs: 120

--- a/src/api/controllers/BlockchainController.ts
+++ b/src/api/controllers/BlockchainController.ts
@@ -1,119 +1,30 @@
 import {FastifyRequest, FastifyReply} from 'fastify';
-import PointSDKController from './PointSDKController';
-import blockchain from '../../network/blockchain';
-import permissionStore from '../../permissions/PermissionStore';
-
-export type RPCRequestBody = {
-    id: number;
-    method: string;
-    params?: unknown[];
-};
-
-type HandlerFunc = (req: FastifyRequest) => Promise<{
-    status: number;
-    result: unknown;
-}>;
-
-const permissionHandlers: Record<string, HandlerFunc> = {
-    wallet_requestPermissions: async (req: FastifyRequest) => {
-        try {
-            const dappDomain = req.headers.origin;
-            if (!dappDomain) {
-                return {status: 400, result: {message: '`Origin` header is required.'}};
-            }
-
-            const address = blockchain.getOwner();
-            const {params} = req.body as RPCRequestBody;
-
-            // If params is not provided or it's an empty array, revoke all permissions.
-            if (!params || !Array.isArray(params) || params.length === 0) {
-                const id = await permissionStore.revoke(dappDomain, address);
-                return {
-                    status: 200,
-                    result: {permissionsId: id, message: 'Revoked all permissions.'}
-                };
-            }
-
-            const allowedMethods = params ? Object.keys(params[0] as Record<string, object>) : [];
-            const id = await permissionStore.upsert(dappDomain, address, allowedMethods);
-            return {
-                status: 200,
-                result: {
-                    permissionsId: id,
-                    message: `Permission granted for ${allowedMethods.join(', ')}`
-                }
-            };
-        } catch (err) {
-            return {status: 400, result: err};
-        }
-    },
-    wallet_getPermissions: async (req: FastifyRequest) => {
-        const dappDomain = req.headers.origin;
-        if (!dappDomain) {
-            return {status: 400, result: {message: '`Origin` header is required.'}};
-        }
-
-        const address = blockchain.getOwner();
-        const permissions = await permissionStore.get(dappDomain, address);
-        return {status: 200, result: permissions || null};
-    }
-};
-
-// Handlers for methods that are not defined in EIP-1474 but that we still support.
-// For example, for compatibility with MetaMask's API.
-const specialHandlers: Record<string, HandlerFunc> = {
-    eth_requestAccounts: async (req: FastifyRequest) => {
-        const {params, id} = req.body as RPCRequestBody;
-        try {
-            const result = await blockchain.send('eth_accounts', params, id);
-            return {status: 200, result};
-        } catch (err) {
-            const statusCode = err.code === -32603 ? 500 : 400;
-            return {status: statusCode, result: err};
-        }
-    }
-};
+import config from 'config';
+const PointSDKController = require('./PointSDKController');
+import handleRPC, {RPCRequest} from '../../rpc/rpc-handlers';
 
 class BlockchainController extends PointSDKController {
     private req: FastifyRequest;
     private reply: FastifyReply;
 
     constructor(ctx: unknown, req: FastifyRequest, reply: FastifyReply) {
-        super(ctx);
+        super(ctx, req);
         this.req = req;
         this.reply = reply;
     }
 
     async request() {
-        const {method, params, id} = this.req.body as RPCRequestBody;
-
-        // Check for methods related to permissions.
-        const permissionHandler = permissionHandlers[method];
-        if (permissionHandler) {
-            const {status, result} = await permissionHandler(this.req);
-            this.reply.status(status);
-            return result;
+        // Check Auth
+        const SDK_AUTH_KEY = config.get('api.sdk_auth_key');
+        if (this.req.headers.authorization !== `Bearer ${SDK_AUTH_KEY}`) {
+            this.reply.status(401);
+            return {message: 'Missing or invalid auth token.'};
         }
 
-        // Check for non-standard (EIP-1474) methods.
-        const specialHandler = specialHandlers[method];
-        if (specialHandler) {
-            const {status, result} = await specialHandler(this.req);
-            this.reply.status(status);
-            return result;
-        }
-
-        // `method` is a standard RPC method (EIP-1474).
-        try {
-            // TODO: do some input validation because sending wrong params could cause a crash.
-            const result = await blockchain.send(method, params, id);
-            return result;
-        } catch (err) {
-            // As per EIP-1474, -32603 means internal error.
-            const statusCode = err.code === -32603 ? 500 : 400;
-            this.reply.status(statusCode);
-            return err;
-        }
+        const body = this.req.body as RPCRequest;
+        const {status, result} = await handleRPC({...body, origin: this.req.headers.origin});
+        this.reply.status(status);
+        return result;
     }
 }
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,7 +3,6 @@ const fastifyWs = require('fastify-websocket');
 const config = require('config');
 const logger = require('../core/log');
 const log = logger.child({module: 'ApiServer'});
-const methodPermissionMdw = require('./middleware/rpc-method-permission');
 
 class ApiServer {
     constructor(ctx) {
@@ -70,7 +69,6 @@ class ApiServer {
             this.server.route({
                 method: apiRoute[0],
                 url: apiRoute[1],
-                preHandler: [methodPermissionMdw],
                 handler: async (request, reply) => {
                     const controller = new (require('./controllers/' + controllerName))(
                         this.ctx,

--- a/src/api/middleware/rpc-method-permission.ts
+++ b/src/api/middleware/rpc-method-permission.ts
@@ -1,13 +1,13 @@
 import {FastifyReply, FastifyRequest} from 'fastify';
-import {RPCRequestBody} from '../controllers/BlockchainController';
+import {RPCRequest} from '../../rpc/rpc-handlers';
 import blockchain from '../../network/blockchain';
 import permissionStore from '../../permissions/PermissionStore';
 
-const RESTRICTED_METHODS = ['eth_sendTransaction'];
+const RESTRICTED_METHODS = [''];
 
 async function methodPermissionMdw(req: FastifyRequest, reply: FastifyReply) {
     if (req.body) {
-        const {method} = req.body as RPCRequestBody;
+        const {method} = req.body as RPCRequest;
 
         if (RESTRICTED_METHODS.includes(method)) {
             const dappDomain = req.headers.origin;
@@ -33,5 +33,4 @@ async function methodPermissionMdw(req: FastifyRequest, reply: FastifyReply) {
     }
 }
 
-// Need to keep it like this because of the way it's imported.
-module.exports = methodPermissionMdw;
+export default methodPermissionMdw;

--- a/src/api/sockets/ZProxySocketController.js
+++ b/src/api/sockets/ZProxySocketController.js
@@ -66,7 +66,7 @@ class ZProxySocketController {
                 case SUBSCRIPTION_REQUEST_TYPES.RPC: {
                     const {method, params, id} = request;
                     const {result} = await handleRPC({method, params, id});
-                    return this.pushSubscriptionEvent({
+                    return this.pushRPCMessage({
                         request,
                         subscriptionId: null,
                         type: SUBSCRIPTION_EVENT_TYPES.RPC,
@@ -98,6 +98,17 @@ class ZProxySocketController {
                 }
             });
         }
+    }
+
+    pushToSender(msg) {
+        if (this.ws) {
+            this.ws.send(JSON.stringify(msg));
+        }
+    }
+
+    pushRPCMessage(msg) {
+        log.info(msg, 'Pushing RPC message');
+        return this.pushToSender(msg);
     }
 
     pushSubscriptionEvent({type, subscriptionId, request, data}) {

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -235,7 +235,25 @@ const attachCommonHandler = (server: FastifyInstance, ctx: any) => {
     const wsHandler = ({socket}: SocketStream, {hostname}: FastifyRequest) =>
         void new ZProxySocketController(ctx, socket, server.websocketServer, hostname);
 
-    server.route({method: 'GET', url: '*', handler, wsHandler});
+    // Handle websocket requests.
+    server.route({
+        method: 'GET',
+        url: '/ws',
+        preValidation: async (
+            req: FastifyRequest<{Querystring: Record<string, string>}>,
+            reply
+        ) => {
+            if (req.query.token !== config.get('api.sdk_auth_key')) {
+                log.error('Invalid Client KEY for websocket connection.');
+                await reply.status(401).send('not authenticated');
+            }
+        },
+        handler: async () => undefined, // to avoid 'handler not defined' error.
+        wsHandler
+    });
+
+    // Handle REST API requests.
+    server.route({method: 'GET', url: '*', handler});
     server.route({method: 'POST', url: '*', handler});
 };
 

--- a/src/network/blockchain.js
+++ b/src/network/blockchain.js
@@ -347,7 +347,10 @@ blockchain.sendToContract = async (
         if (k.split('(')[0] === methodName && k.includes('(')) {
             // example of k: send(address,bytes32,string)
             let paramIdx = 0;
-            const kArgTypes = k.split('(')[1].replace(')', '').split(',');
+            const kArgTypes = k
+                .split('(')[1]
+                .replace(')', '')
+                .split(',');
             for (const kArgType of kArgTypes) {
                 if (kArgType === 'bytes32') {
                     // Potential candidate for conversion
@@ -645,7 +648,7 @@ blockchain.getTransactionsByAccount = async (account, startBlockNumber, endBlock
 
         var block = web3.eth.getBlock(i, true);
         if (block != null && block.transactions != null) {
-            block.transactions.forEach(function (e) {
+            block.transactions.forEach(function(e) {
                 if (account === '*' || account === e.from || account === e.to) {
                     txs.push(e);
                     // log.debug('   tx hash         : ' + e.hash + '\n'

--- a/src/permissions/PendingTxs.test.ts
+++ b/src/permissions/PendingTxs.test.ts
@@ -1,0 +1,62 @@
+import {PendingTxs} from './PendingTxs';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const EXPIRATION_SECS = 3;
+let pendingTxs = new PendingTxs(EXPIRATION_SECS);
+
+beforeEach(() => {
+    pendingTxs = new PendingTxs(EXPIRATION_SECS);
+});
+
+describe('PendingTxs', () => {
+    jest.setTimeout(10 * 1000);
+
+    it(`should add request to the pool and return it's ID`, () => {
+        const tx = {method: 'eth_sendTransaction', params: [{value: 1}]};
+        const reqId = pendingTxs.add(tx.params);
+        expect(reqId).toBeTruthy();
+    });
+
+    it(`should find request by it's ID`, () => {
+        // Add
+        const tx = {method: 'eth_sendTransaction', params: [{value: 2}]};
+        const id = pendingTxs.add(tx.params);
+
+        // Retrieve
+        const got = pendingTxs.find(id);
+        expect(got?.params).toEqual(tx.params);
+    });
+
+    it(`should delete a request by it's ID`, () => {
+        // Add
+        const tx = {method: 'eth_sendTransaction', params: [{value: 3}]};
+        const id = pendingTxs.add(tx.params);
+
+        // Remove
+        const got = pendingTxs.rm(id);
+        expect(got).toEqual(id);
+        expect(pendingTxs.find(id)).toBeUndefined();
+    });
+
+    it(`should delete a stale request`, async () => {
+        // Add
+        const tx = {method: 'eth_sendTransaction', params: [{value: 4}]};
+        const id = pendingTxs.add(tx.params);
+
+        // Retrieve (after expiration)
+        await sleep((EXPIRATION_SECS + 2) * 1000);
+        const got = pendingTxs.find(id);
+        expect(got).toBeUndefined();
+    });
+
+    it('should retrieve a request that has not expire yet', async () => {
+        // Add
+        const tx = {method: 'eth_sendTransaction', params: [{value: 5}]};
+        const id = pendingTxs.add(tx.params);
+
+        // Retrieve (before expiration)
+        await sleep((EXPIRATION_SECS - 2) * 1000);
+        const got = pendingTxs.find(id);
+        expect(got?.params).toEqual(tx.params);
+    });
+});

--- a/src/permissions/PendingTxs.ts
+++ b/src/permissions/PendingTxs.ts
@@ -1,0 +1,76 @@
+import crypto from 'crypto';
+import config from 'config';
+import {PendingTx} from './types';
+
+export class PendingTxs {
+    private expirationSecs: number;
+    private pendingTransactions: Record<string, PendingTx> = {};
+
+    constructor(expirationSecs: number) {
+        this.expirationSecs = expirationSecs;
+    }
+
+    private calculateExpiration() {
+        const now = new Date();
+        return new Date(now.setSeconds(now.getSeconds() + this.expirationSecs));
+    }
+
+    private generateId() {
+        return crypto.randomBytes(32).toString('hex');
+    }
+
+    /**
+     * Deletes old transactions from the pending requests pool.
+     * It's run every time `find()` is invoked to only return valid transactions.
+     * But the method is exposed so that it can be called at will.
+     */
+    gc() {
+        const now = new Date();
+        Object.keys(this.pendingTransactions).forEach(id => {
+            if (now >= this.pendingTransactions[id].expiresAt) {
+                delete this.pendingTransactions[id];
+            }
+        });
+    }
+
+    /**
+     * Adds a transaction to the pool of pending requests
+     * for future processing.
+     */
+    add(params: unknown[]) {
+        const reqId = this.generateId();
+        const expiresAt = this.calculateExpiration();
+        this.pendingTransactions[reqId] = {params, expiresAt};
+        return reqId;
+    }
+
+    /**
+     * Retrieves a pending request by ID.
+     * It runs `gc` first, so it wil only return a request
+     * if it is not expired.
+     */
+    find(reqId: string): PendingTx | undefined {
+        // Remove old requests first.
+        this.gc();
+        return this.pendingTransactions[reqId];
+    }
+
+    /**
+     * Deletes a transaction from the pool of pending requests.
+     */
+    rm(reqId: string) {
+        if (!this.pendingTransactions[reqId]) {
+            return null;
+        }
+        delete this.pendingTransactions[reqId];
+        return reqId;
+    }
+}
+
+const EXPIRATION_SECS = config.has('rpc.send_transaction_timeout_secs')
+    ? Number(config.get('rpc.send_transaction_timeout_secs'))
+    : 60 * 2; // 2 minutes
+
+const pendingTxs = new PendingTxs(EXPIRATION_SECS);
+
+export default pendingTxs;

--- a/src/permissions/types.ts
+++ b/src/permissions/types.ts
@@ -5,3 +5,8 @@ export type PermissionRecord = {
     parentCapabilities: string[]; // allowed RPC methods
     account: string; // wallet address
 };
+
+export type PendingTx = {
+    expiresAt: Date;
+    params: unknown[];
+};

--- a/src/rpc/rpc-handlers.ts
+++ b/src/rpc/rpc-handlers.ts
@@ -1,0 +1,152 @@
+import pendingTxs from '../permissions/PendingTxs';
+// import permissionStore from '../permissions/PermissionStore';
+import blockchain from '../network/blockchain';
+
+export type RPCRequest = {
+    id: number;
+    method: string;
+    params?: unknown[];
+    origin?: string;
+};
+
+type HandlerFunc = (
+    data: RPCRequest
+) => Promise<{
+    status: number;
+    result: unknown;
+}>;
+
+// Handlers for non-standard methods, or methods with custom logic.
+const specialHandlers: Record<string, HandlerFunc> = {
+    eth_requestAccounts: async data => {
+        const {params, id} = data;
+        try {
+            const result = await blockchain.send('eth_accounts', params, id);
+            return {status: 200, result};
+        } catch (err) {
+            const statusCode = err.code === -32603 ? 500 : 400;
+            return {status: statusCode, result: err};
+        }
+    },
+    eth_sendTransaction: async data => {
+        const {params} = data;
+        if (!params) {
+            return {status: 400, result: {message: 'Missing `params` in request body.'}};
+        }
+
+        // Store request for future processing,
+        // and send `reqId` to client so it can ask user approval.
+        const reqId = pendingTxs.add(params);
+        return {status: 200, result: {reqId, params}};
+    },
+    eth_confirmTransaction: async data => {
+        const {params, id} = data;
+        if (!params || !Array.isArray(params) || params.length !== 1 || !params[0].reqId) {
+            return {status: 400, result: {message: 'Missing `params[0].reqId` in request body.'}};
+        }
+
+        try {
+            const {reqId} = params[0] as {reqId: string};
+            const tx = pendingTxs.find(reqId);
+            if (!tx) {
+                return {
+                    status: 404,
+                    result: {message: `Tx for request id "${reqId}" has not been found.`}
+                };
+            }
+
+            pendingTxs.rm(reqId);
+            const result = await blockchain.send('eth_sendTransaction', tx.params, id);
+            return {status: 200, result};
+        } catch (err) {
+            const statusCode = err.code === -32603 ? 500 : 400;
+            return {status: statusCode, result: err};
+        }
+    }
+};
+
+// Handlers for methods related to permissions.
+const permissionHandlers: Record<string, HandlerFunc> = {
+    wallet_requestPermissions: async data => {
+        const statusCode = 4200; // As per EIP-1193
+        const message = 'Unsupported Method `wallet_requestPermissions`.';
+        return {status: 400, result: {statusCode, message, id: data.id}};
+        /*
+        try {
+            const {params, origin} = data;
+            if (!origin) {
+                return {status: 400, result: {message: '`Origin` header is required.'}};
+            }
+
+            const address = blockchain.getOwner();
+
+            // If params is not provided or it's an empty array, revoke all permissions.
+            if (!params || !Array.isArray(params) || params.length === 0) {
+                const id = await permissionStore.revoke(origin, address);
+                return {
+                    status: 200,
+                    result: {permissionsId: id, message: 'Revoked all permissions.'}
+                };
+            }
+
+            const allowedMethods = params ? Object.keys(params[0] as Record<string, object>) : [];
+            const id = await permissionStore.upsert(origin, address, allowedMethods);
+            return {
+                status: 200,
+                result: {
+                    permissionsId: id,
+                    message: `Permission granted for ${allowedMethods.join(', ')}`
+                }
+            };
+        } catch (err) {
+            return {status: 400, result: err};
+        }
+        */
+    },
+    wallet_getPermissions: async data => {
+        const statusCode = 4200; // As per EIP-1193
+        const message = 'Unsupported Method `wallet_getPermissions`.';
+        return {status: 400, result: {statusCode, message, id: data.id}};
+        /*
+        const {origin} = data;
+        if (!origin) {
+            return {status: 400, result: {message: '`Origin` header is required.'}};
+        }
+
+        const address = blockchain.getOwner();
+        const permissions = await permissionStore.get(origin, address);
+        return {status: 200, result: permissions || null};
+        */
+    }
+};
+
+/**
+ * Send RPC method calls to the blockchain client.
+ */
+const handleRPC: HandlerFunc = async data => {
+    try {
+        // Check for methods related to permissions.
+        const permissionHandler = permissionHandlers[data.method];
+        if (permissionHandler) {
+            const res = await permissionHandler(data);
+            return res;
+        }
+
+        // Check for special/custom methods.
+        const specialHandler = specialHandlers[data.method];
+        if (specialHandler) {
+            const res = await specialHandler(data);
+            return res;
+        }
+
+        // `method` is a standard RPC method (EIP-1474).
+        const result = await blockchain.send(data.method, data.params, data.id);
+        return {status: 200, result};
+    } catch (err) {
+        // As per EIP-1474, -32603 means internal error.
+        const statusCode = err.code === -32603 ? 500 : 400;
+        return {status: statusCode, result: err};
+    }
+};
+
+export default handleRPC;


### PR DESCRIPTION
URL to connect to WS: `wss://point/ws?token=POINTSDK_TOKEN`.

- The auth token is a hardcoded string for now, there's not signature checks, it's just a string comparison. The expected token is set in config `api.sdk_auth_key`.
- I introduced a dedicated route for WS connections: `/ws`. The reason is that I wanted to include a _preValidation_ hook that would only affect the WS connections and not the REST API requests. But if you think this could introduce breaking changes, I can leave it as it was and find another way of using the _preValidation_ hook.

RPC requests can be made by sending messages with the `type: 'rpc'`, for example:
```javascript
// Get account balance
{
    "type": "rpc",
    "method": "eth_getBalance",
    "params": ["0x916f8e7566dd63d7c444468cadea37e80f7f8048", "latest"]
}

// Initiate tx
{
    "type": "rpc",
    "method": "eth_sendTransaction",
    "params": [
        {
            "from": "0x916f8e7566dd63d7c444468cadea37e80f7f8048",
            "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
            "value": "0x1bc16d674ec80000",
            "gas": "0x76c0",
            "gasPrice": "0x9184e72a000",
            "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
        }
    ]
}

// Confirm tx
{
    "type": "rpc",
    "method": "eth_confirmTransaction",
    "params": [
      {
        "reqId": "6bf07cdb83406acafec1ee9260292997915ad5fd5d5832ad3d1f5471fe8d5d93"
      }
    ]
}
````

Tx must be confirmed within 2 minutes, otherwise they will expire. This is set in config `rpc.send_transaction_timeout_secs`.

BTW: RPC requests can also be made to the REST API endpoint `/v1/api/blockchain`. In this case, use the header `Authorization: Bearer POINTSDK_TOKEN`.