### PR TITLE
PN-122 Add github action to publish release on push to `master`.

### DIFF
--- a/.github/workflows/pkg.yaml
+++ b/.github/workflows/pkg.yaml
@@ -59,8 +59,8 @@ jobs:
       with:
         tag_name: ${{ steps.get_source_tag.outputs.SOURCE_TAG }}
         release_name: Release ${{ steps.get_source_tag.outputs.SOURCE_TAG }}
-        draft: false
-        prerelease: true
+        draft: true
+        prerelease: false
 
     - name: upload linux artefact
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    name: Publish Latest Draft Releas
+    name: Publish Latest Draft Release
     runs-on: ubuntu-latest
     steps:
     - uses: ivangabriele/publish-latest-release@v3

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,0 +1,16 @@
+# Thiw workflow publishes the latest draft release
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Publish Latest Draft Releas
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ivangabriele/publish-latest-release@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The idea is that with these changes, the flow to release Point Node would be:

- tag a commit on `develop` branch -> triggers github action to create a _DRAFT_ release
- test the _DRAFT_ release
- merge `develop` into `master`
- push `master` -> triggers github action to publish the _DRAFT_ release