### PR TITLE
Fix merkle function by flatting the returned array

### DIFF
--- a/src/util/merkle.ts
+++ b/src/util/merkle.ts
@@ -41,5 +41,5 @@ export const merkle = (values: Uint8Array[], digestFn: (data: Uint8Array) => Uin
         initial_iteration = false;
     } while (level.length > 1);
 
-    return [...levels];
+    return [...levels].flat();
 };


### PR DESCRIPTION
Before refactoring utils the original function was:

```
return [].concat.apply([], levels);
```

Because apply takes an array as argument, it's flattening the result.

That chunk of code was replaced by:

```
return [...levels]
```

So if you console.log and compare the result of these functions you get this
```
{
  usingDestructuring: [
    [
      <Buffer a6 dd 5f 01 96 0f 4e 47 72 cd 8b 2f 89 74 02 d2 01 db c1 d5 71 d0 8e 44 c2 56 e6 07 5a 94 2a 32>,
      <Buffer 36 d3 c8 ea f9 47 10 91 db ab 4d 2c 1e d5 bd 6c 67 87 f5 5e 13 7c 38 31 e2 df d3 f9 93 f6 8b e3>
    ],
    [
      <Buffer 77 42 f5 70 f7 4b af 2e 65 d5 43 9f d0 24 34 4d 00 b6 01 40 7f 31 d1 b9 15 d8 b0 38 31 0b 1b 82>
    ]
  ],
  usingConcantApply: [
    <Buffer a6 dd 5f 01 96 0f 4e 47 72 cd 8b 2f 89 74 02 d2 01 db c1 d5 71 d0 8e 44 c2 56 e6 07 5a 94 2a 32>,
    <Buffer 36 d3 c8 ea f9 47 10 91 db ab 4d 2c 1e d5 bd 6c 67 87 f5 5e 13 7c 38 31 e2 df d3 f9 93 f6 8b e3>,
    <Buffer 77 42 f5 70 f7 4b af 2e 65 d5 43 9f d0 24 34 4d 00 b6 01 40 7f 31 d1 b9 15 d8 b0 38 31 0b 1b 82>
  ]
}
```

So we could keep the original code or flatten the result as I did in this pr.