### PR TITLE
Parse chunk converted to string rather than buffer

### DIFF
--- a/src/client/storage/index.js
+++ b/src/client/storage/index.js
@@ -366,14 +366,14 @@ const getFile = async (rawId, encoding = 'utf8', useCache = true) => {
         }
 
         log.debug({fileId: file.id}, 'Processing chunk info');
-
+        const toParse = chunkInfoString.slice(CHUNKINFO_PROLOGUE.length);
         const {
             type,
             hash,
             chunks,
             filesize,
             merkle: merkleHash
-        } = JSON.parse(chunkInfo.slice(CHUNKINFO_PROLOGUE.length + 1));
+        } = JSON.parse(toParse);
 
         if (type !== 'file') {
             throw new Error('Bad file type');


### PR DESCRIPTION
On first loading of a contract the variable chunkInfo is a buffer returned by getChunk function, but once the chunk is on our database that chunk is a string. So on first try to parse the chunkInfo it fails, but once the chunk is in the db it works ok. Parsing the string version solves the issue.