### PR TITLE
Add missing hardhat dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,6 +1494,16 @@
         "@ethersproject/bytes": "^5.6.0"
       }
     },
+    "@ethersproject/basex": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
+      "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0"
+      }
+    },
     "@ethersproject/bignumber": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
@@ -1527,6 +1537,24 @@
         "@ethersproject/bignumber": "^5.6.0"
       }
     },
+    "@ethersproject/contracts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.0.tgz",
+      "integrity": "sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.6.0",
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0"
+      }
+    },
     "@ethersproject/hash": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
@@ -1540,6 +1568,55 @@
         "@ethersproject/logger": "^5.6.0",
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.0.tgz",
+      "integrity": "sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/basex": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/pbkdf2": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/wordlists": "^5.6.0"
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
+      "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hdnode": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/pbkdf2": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true
+        }
       }
     },
     "@ethersproject/keccak256": {
@@ -1564,11 +1641,66 @@
         "@ethersproject/logger": "^5.6.0"
       }
     },
+    "@ethersproject/pbkdf2": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
+      "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0"
+      }
+    },
     "@ethersproject/properties": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
       "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
       "requires": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.4.tgz",
+      "integrity": "sha512-WAdknnaZ52hpHV3qPiJmKx401BLpup47h36Axxgre9zT+doa/4GC/Ne48ICPxTm0BqndpToHjpLP1ZnaxyE+vw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/basex": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/networks": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/web": "^5.6.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true
+        }
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
+      "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/logger": "^5.6.0"
       }
     },
@@ -1611,6 +1743,20 @@
         }
       }
     },
+    "@ethersproject/solidity": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
+      "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
     "@ethersproject/strings": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
@@ -1637,6 +1783,40 @@
         "@ethersproject/signing-key": "^5.6.0"
       }
     },
+    "@ethersproject/units": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
+      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.0.tgz",
+      "integrity": "sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/hdnode": "^5.6.0",
+        "@ethersproject/json-wallets": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/wordlists": "^5.6.0"
+      }
+    },
     "@ethersproject/web": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
@@ -1644,6 +1824,19 @@
       "requires": {
         "@ethersproject/base64": "^5.6.0",
         "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
+      "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
         "@ethersproject/logger": "^5.6.0",
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/strings": "^5.6.0"
@@ -3900,6 +4093,12 @@
         }
       }
     },
+    "bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "dev": true
+    },
     "bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
@@ -4643,6 +4842,82 @@
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dev": true,
+      "requires": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+          "dev": true
+        }
       }
     },
     "commander": {
@@ -6561,6 +6836,44 @@
         "scrypt-js": "^3.0.1",
         "utf8": "^3.0.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "ethers": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.4.tgz",
+      "integrity": "sha512-62UIfxAQXdf67TeeOaoOoPctm5hUlYgfd0iW3wxfj7qRYKDcvvy0f+sJ3W2/Pyx77R8dblvejA8jokj+lS+ATQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "5.6.1",
+        "@ethersproject/abstract-provider": "5.6.0",
+        "@ethersproject/abstract-signer": "5.6.0",
+        "@ethersproject/address": "5.6.0",
+        "@ethersproject/base64": "5.6.0",
+        "@ethersproject/basex": "5.6.0",
+        "@ethersproject/bignumber": "5.6.0",
+        "@ethersproject/bytes": "5.6.1",
+        "@ethersproject/constants": "5.6.0",
+        "@ethersproject/contracts": "5.6.0",
+        "@ethersproject/hash": "5.6.0",
+        "@ethersproject/hdnode": "5.6.0",
+        "@ethersproject/json-wallets": "5.6.0",
+        "@ethersproject/keccak256": "5.6.0",
+        "@ethersproject/logger": "5.6.0",
+        "@ethersproject/networks": "5.6.2",
+        "@ethersproject/pbkdf2": "5.6.0",
+        "@ethersproject/properties": "5.6.0",
+        "@ethersproject/providers": "5.6.4",
+        "@ethersproject/random": "5.6.0",
+        "@ethersproject/rlp": "5.6.0",
+        "@ethersproject/sha2": "5.6.0",
+        "@ethersproject/signing-key": "5.6.0",
+        "@ethersproject/solidity": "5.6.0",
+        "@ethersproject/strings": "5.6.0",
+        "@ethersproject/transactions": "5.6.0",
+        "@ethersproject/units": "5.6.0",
+        "@ethersproject/wallet": "5.6.0",
+        "@ethersproject/web": "5.6.0",
+        "@ethersproject/wordlists": "5.6.0"
       }
     },
     "ethjs-unit": {
@@ -11870,6 +12183,12 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
       "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
     },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "dev": true
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -13485,6 +13804,12 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
     },
+    "string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "dev": true
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -13783,6 +14108,32 @@
         }
       }
     },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dev": true,
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+          "dev": true
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+          "dev": true
+        }
+      }
+    },
     "tar": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
@@ -14010,6 +14361,18 @@
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
       "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
     },
+    "ts-command-line-args": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.2.1.tgz",
+      "integrity": "sha512-mnK68QA86FYzQYTSA/rxIjT/8EpKsvQw9QkawPic8I8t0gjAOw3Oa509NIRoaY1FmH7hdrncMp7t7o+vYoceNQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "string-format": "^2.0.0"
+      }
+    },
     "ts-essentials": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
@@ -14146,6 +14509,66 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "typechain": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.0.0.tgz",
+      "integrity": "sha512-rqDfDYc9voVAhmfVfAwzg3VYFvhvs5ck1X9T/iWkX745Cul4t+V/smjnyqrbDzWDbzD93xfld1epg7Y/uFAesQ==",
+      "dev": true,
+      "requires": {
+        "@types/prettier": "^2.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^7.0.0",
+        "glob": "7.1.7",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.3.1",
+        "ts-command-line-args": "^2.2.0",
+        "ts-essentials": "^7.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
       }
     },
     "typedarray-to-buffer": {
@@ -15215,6 +15638,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dev": true,
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+          "dev": true
+        }
+      }
     },
     "workerpool": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",
+    "@ethersproject/providers": "^5.6.4",
     "@types/async": "^3.2.12",
     "@types/commander": "^2.12.2",
     "@types/config": "^0.0.41",
@@ -87,6 +88,7 @@
     "eslint": "^8.9.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-prefer-arrow": "^1.2.3",
+    "ethers": "^5.6.4",
     "hardhat": "^2.8.4",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
@@ -98,6 +100,7 @@
     "sequelize-mig": "^3.1.3",
     "solhint": "^3.3.7",
     "ts-node": "^10.5.0",
+    "typechain": "^8.0.0",
     "typescript": "^4.6.2"
   },
   "scripts": {


### PR DESCRIPTION
Without these dependencies installed on the parent folder,
hardhat was throwing an error when running:
  `point deploy <zapp> --contracts`.

Further details in this [Slack thread](https://point-labs.slack.com/archives/C02U1P7U4Q2/p1651230832849709).

If the `metamask-api` PR is merged before this one. I'll update this PR by installing dependencies with `npm 8`, so that it generates a _lockFileVersion 2_ instead of 1.