### PR TITLE
PN-135 Fetch chunks from S3 before Arweave

### DIFF
--- a/config/dockertest.yaml
+++ b/config/dockertest.yaml
@@ -13,6 +13,8 @@ storage:
   arweave_host: arweave-node
   arweave_protocol: http
   arweave_port: 1984
+  request_timeout: 120000
+  upload_expire: 120000
 network:
   web3:
     ynet: http://blockchain_node:7545

--- a/src/client/storage/storage.ts
+++ b/src/client/storage/storage.ts
@@ -1,5 +1,6 @@
 import Arweave from 'arweave';
 import config from 'config';
+import {AxiosResponse} from 'axios';
 
 const arweave = Arweave.init({
     port: Number(config.get('storage.arweave_port')),
@@ -8,8 +9,14 @@ const arweave = Arweave.init({
     timeout: config.get('storage.request_timeout')
 });
 
-export const storage = {
+export const storage: {
+    getDataByTxId(txId: string): Promise<string | Uint8Array>;
+    getTxFromCache(txId: string): Promise<AxiosResponse<Uint8Array>>;
+} = {
     getDataByTxId(txId: string) {
         return arweave.transactions.getData(txId, {decode: true});
+    },
+    getTxFromCache(txId: string) {
+        return arweave.api.get(`/${txId}`, {responseType: 'arraybuffer'});
     }
 };


### PR DESCRIPTION
The order in which chunks are retrieved is:
  - local cache (sqlite)
  - bundler's backup (S3)
  - Arweave's cache
  - Arweave's node(s)

I tested a few zApps with these changes (disabling local cache) and 100% of the chunks are coming from S3+Arweave cache:
- social.point
  - 10 -> s3
  - 32 -> arcache
- email.point
  - 2 -> s3
  - 2 -> arcache
- blog
  - 18 arcache

I think the reason not all of them are coming from S3 is that "old" content is uploaded under a random string instead of chunkId. Maybe we could run a script that:
1. Downloads all files with a name that is 20 characters long (the random string ids)
2. Hashes the content
3. Checks if the hash from step 2 exists in S3, if it doesn't, re-upload the file with the hash as name
4. Delete the file from step 1 to save some space

But I wouldn't consider it as a priority since missing chunks from S3 can be successfully retrieved from Arweave's cache.