### PR TITLE
Implemented ZApp links as icons

### DIFF
--- a/internal/explorer.point/src/custom.css
+++ b/internal/explorer.point/src/custom.css
@@ -15,3 +15,41 @@ a.nav-link.active {
     height: 1.6em; 
     margin-right: 0.8em;
 }
+
+.zapps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, 92px);
+    grid-gap: 10px;
+    padding: 10px;
+}
+
+.zapp {
+    min-height: 32px;
+    aspect-ratio: 1/1;
+    align-items: center;
+    justify-content: center;    
+    border:  1px solid #eee;
+    background-color: #eee;    
+    border-radius: 25%;
+}
+
+.zapp-icon {
+  width: 60%;
+  margin: auto;
+  margin-top: 16px;
+  display: block;
+}
+
+.zapp-icon-container {
+    -webkit-mask-size: 100% 100%;
+    height: 100%;
+    margin: auto;
+    vertical-align: middle;
+}
+
+.zapp-title-container {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/internal/explorer.point/src/pages/Home.jsx
+++ b/internal/explorer.point/src/pages/Home.jsx
@@ -1,7 +1,9 @@
 import Container from 'react-bootstrap/Container'
+
 import { useState,useEffect } from "react";
 import { useAppContext } from '../context/AppContext';
 import Loading from '../components/Loading';
+import appLogo from '../assets/pointlogo.png'
 
 export default function Home() {
   const { walletIdentity } = useAppContext();
@@ -35,13 +37,24 @@ export default function Home() {
 
   const renderZappEntry = (k) => {
     return (
-        <li key={k}><a href={ 'https://' + k } target="_blank">{ k } &mdash; { featuredZapps[k] }</a></li>
+      <a href={ 'https://' + k } target="_blank">
+        <div className="zapp" key={k}>
+          <div className="zapp-icon-container">
+            <img alt={k} className="zapp-icon" src={`https://${k}/favicon.ico`}
+              onError={({ currentTarget }) => { currentTarget.src = appLogo; }}
+            />
+          </div>
+          <div className="zapp-title-container">
+            <span>{ featuredZapps[k] }</span>
+          </div>
+        </div>
+      </a>
     )
   }
 
-  let zappsList = <p>No ZApp deployed yet.</p>;
+  let zappsList = <p>No ZApps deployed yet.</p>;
   if(zapps.length > 0){
-    zappsList = <ul>{zapps.map((k) => renderZappEntry(k))}</ul>;
+    zappsList = <div className="zapps">{zapps.map((k) => renderZappEntry(k))}</div>;
   }
 
   return (
@@ -55,6 +68,8 @@ export default function Home() {
 
         <h5>Explore deployed websites</h5>
         {isLoading ? <Loading /> : zappsList}
+
+
       </Container>
     </>
   );


### PR DESCRIPTION
This PR includes a small change to show deployed ZApps as icons

- It is necessary to build changes using npm run build inside of the folder /internal/explorer.point/
- The icons for each app comes from the favicon.ico of each ZApp, in the case that the favicon.ico is not available, a placeholder (currently the point logo) is loaded.