### PR TITLE
Convert identity to lower case before checking signature

### DIFF
--- a/hardhat/contracts/Identity.sol
+++ b/hardhat/contracts/Identity.sol
@@ -103,8 +103,8 @@ contract Identity is Initializable, UUPSUpgradeable, OwnableUpgradeable{
         address signer = ecrecover(prefixedHashMessage, _v, _r, _s);
         require(signer == oracleAddress, "Identity claim msg must be signed by the oracle");
 
-        bytes32 expectedMsgFree = keccak256(abi.encodePacked(handle, "|", Strings.toHexString(uint256(uint160(identityOwner)), 20), "|free"));
-        bytes32 expectedMsgTaken = keccak256(abi.encodePacked(handle, "|", Strings.toHexString(uint256(uint160(identityOwner)), 20), "|taken"));
+        bytes32 expectedMsgFree = keccak256(abi.encodePacked(_toLower(handle), "|", Strings.toHexString(uint256(uint160(identityOwner)), 20), "|free"));
+        bytes32 expectedMsgTaken = keccak256(abi.encodePacked(_toLower(handle), "|", Strings.toHexString(uint256(uint160(identityOwner)), 20), "|taken"));
 
         require(_hashedMessage == expectedMsgFree || _hashedMessage == expectedMsgTaken, "Invalid identity claim msg");
 

--- a/src/api/controllers/IdentityController.js
+++ b/src/api/controllers/IdentityController.js
@@ -65,7 +65,7 @@ function getIdentityActivationCode(owner) {
 function getHashedMessage(identity, owner, type) {
     const lowerCaseOwner = owner.toLowerCase();
     const prefix = lowerCaseOwner.indexOf('0x') !== 0 ? '0x' : '';
-    const hashedMessage = ethers.utils.id(`${identity}|${prefix}${lowerCaseOwner}|${type}`);
+    const hashedMessage = ethers.utils.id(`${identity.toLowerCase()}|${prefix}${lowerCaseOwner}|${type}`);
     return hashedMessage;
 }
 


### PR DESCRIPTION
Fix the problem of registering identities with capital letters. 
