### PR TITLE
Add ability for proxy to resolve `.sol` domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
       "#(.*)": "<rootDir>/core/$1"
     },
     "modulePathIgnorePatterns": [
-      "docker"
+      "docker",
+      "dist"
     ],
     "testEnvironment": "node",
     "testRunner": "jest-circus/runner",

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -2,6 +2,7 @@
 import path from 'path';
 import {promises as fs} from 'fs';
 import {parse} from 'query-string';
+import axios from 'axios';
 import {makeSurePathExists, readFileByPath} from '../../../util';
 import {FastifyInstance, FastifyReply, FastifyRequest} from 'fastify';
 import ZProxySocketController from '../../../api/sockets/ZProxySocketController';
@@ -14,11 +15,14 @@ import {getContentTypeFromExt, getParamsAndTemplate} from '../proxyUtils';
 import {detectContentType} from 'detect-content-type';
 import config from 'config';
 import {Template, templateManager} from '../templateManager';
-
 import {getMirrorWeb2Page} from './mirror';
-
+import {parseDomainRegistry} from '../../../name_service/registry';
 const {getJSON, getFileIdByPath, getFile} = require('../../storage');
+
 const log = logger.child({module: 'ZProxy'});
+
+const API_URL = `http://${config.get('api.address')}:${config.get('api.port')}`;
+
 const getHttpRequestHandler = (ctx: any) => async (req: FastifyRequest, res: FastifyReply) => {
     try {
         const host = req.headers.host!;
@@ -240,6 +244,125 @@ const getHttpRequestHandler = (ctx: any) => async (req: FastifyRequest, res: Fas
                 }
                 const file = await getFile(renderedId, null);
 
+                const contentType = ext ? getContentTypeFromExt(ext) : detectContentType(file);
+                res.header('content-type', contentType);
+                return file;
+            }
+        } else if (host.endsWith('.sol')) {
+            // For Solana domains, we store Point data in the domain registry.
+            let identity = '';
+            let routesId: string | undefined;
+            let rootDirId: string | undefined;
+            let isAlias = false;
+
+            try {
+                const resp = await axios.get(`${API_URL}/v1/api/identity/resolve/${host}`);
+                if (!resp.data.data?.content.decoded?.trim()) {
+                    const msg = `No data found in the "content" field of the domain registry for "${host}".`;
+                    log.debug({host}, msg);
+                    return res.status(404).send(msg);
+                }
+
+                const pointData = parseDomainRegistry(resp.data.data);
+                isAlias = pointData.isAlias;
+                identity = pointData.identity ? `${pointData.identity}.point` : '';
+                routesId = pointData.routesId;
+                rootDirId = pointData.rootDirId;
+                log.debug({host, identity, routesId, rootDirId, isAlias}, 'Resolved .sol domain');
+            } catch (err) {
+                const statusCode = err.response?.data?.status || 500;
+                const msg = err.response?.data?.data?.errorMsg || 'Error resolving ".sol" domain';
+                log.error(err, msg);
+                return res.status(statusCode).send(msg);
+            }
+
+            // Return bad request if missing data in the domain registry.
+            if (!isAlias && (!identity || !routesId || !rootDirId)) {
+                // If the .sol domain is not an alias to a .point domain, all these
+                // fields need to be present so that we can fetch the content.
+                const msg = `Missing Point information in "${host}" domain registry.`;
+                log.debug({host, identity, routesId, rootDirId, isAlias}, msg);
+                return res.status(400).send(msg);
+            }
+
+            if (isAlias) {
+                // .sol domain is an alias to a .point one, so we fetch the routes
+                // and root directory from our Identity contract, as with any other
+                // .point domain
+                log.debug({host, identity}, '.sol domain is an alias');
+                const version = (queryParams.__point_version as string) ?? 'latest';
+
+                routesId = await blockchain.getZRecord(identity, version);
+                if (!routesId) {
+                    return res
+                        .status(404)
+                        .send('Domain not found (Route file not specified for this domain)');
+                }
+
+                rootDirId = await blockchain.getKeyValue(identity, '::rootDir', version);
+                if (!rootDirId) {
+                    return res.status(404).send(`Root dir id not found for host ${identity}`);
+                }
+            }
+
+            // Fetch routes file
+            const routes = await getJSON(routesId);
+            if (!routes) {
+                return res.status(404).send(`Cannot parse json of zrouteId ${routesId}`);
+            }
+
+            // Download info about root dir
+            const {routeParams, templateFilename, rewritedPath} = getParamsAndTemplate(
+                routes,
+                urlPath
+            );
+
+            if (rewritedPath) {
+                urlPath = rewritedPath;
+            }
+
+            if (templateFilename) {
+                const templateFileId = await getFileIdByPath(rootDirId, templateFilename);
+                const templateFileContents = await getFile(templateFileId);
+                const renderer = new Renderer(ctx, {rootDirId} as any);
+
+                res.header('Content-Type', 'text/html');
+                // TODO: sanitize
+                return renderer.render(templateFileId, templateFileContents, identity, {
+                    ...routeParams,
+                    ...queryParams,
+                    ...((req.body as Record<string, unknown>) ?? {})
+                });
+            } else {
+                // This is a static asset
+                let renderedId;
+                try {
+                    renderedId = await getFileIdByPath(rootDirId, urlPath);
+                } catch (e) {
+                    // Handling the case with SPA reloaded on non-index page:
+                    // we have to return index file, but without changin the URL
+                    // to make client-side routing work
+                    if (Object.keys(routes).length === 1) {
+                        const {templateFilename: indexTemplate} = getParamsAndTemplate(routes, '/');
+                        const templateFileId = await getFileIdByPath(rootDirId, indexTemplate);
+                        const templateFileContents = await getFile(templateFileId);
+                        const renderer = new Renderer(ctx, {rootDirId} as any);
+
+                        res.header('Content-Type', 'text/html');
+                        // TODO: sanitize
+                        return renderer.render(templateFileId, templateFileContents, identity, {
+                            ...routeParams,
+                            ...queryParams,
+                            ...((req.body as Record<string, unknown>) ?? {})
+                        });
+                    }
+                }
+
+                if (!renderedId) {
+                    return res.status(404).send('Not found');
+                }
+
+                const file = await getFile(renderedId, null);
                 const contentType = ext ? getContentTypeFromExt(ext) : detectContentType(file);
                 res.header('content-type', contentType);
                 return file;

--- a/src/name_service/registry.test.ts
+++ b/src/name_service/registry.test.ts
@@ -1,0 +1,59 @@
+import {parseDomainRegistry} from './registry';
+import {DomainRegistry, PointDomainData} from './types';
+
+type TestCase = [DomainRegistry, PointDomainData];
+
+const owner = 'blockchain_address-not_important_for_these_tests';
+
+const testCases: TestCase[] = [
+    [
+        {owner, content: {decoded: 'ipfs=cid', error: null}},
+        {identity: '', isAlias: false, rootDirId: '', routesId: ''}
+    ],
+    [
+        {owner, content: {decoded: 'ipfs=cid;pn_alias=ynet_blog', error: null}},
+        {identity: 'ynet_blog', isAlias: true}
+    ],
+    [
+        {owner, content: {decoded: 'pn_alias=ynet_blog;arwv=chunkId', error: null}},
+        {identity: 'ynet_blog', isAlias: true}
+    ],
+    [
+        {
+            owner,
+            content: {
+                decoded:
+                    'email=a@b.c;pn_id=ynet_blog;pn_root=root-chunk-id;pn_routes=routes-chunk-id',
+                error: null
+            }
+        },
+        {
+            identity: 'ynet_blog',
+            isAlias: false,
+            routesId: 'routes-chunk-id',
+            rootDirId: 'root-chunk-id'
+        }
+    ],
+    [
+        {
+            owner,
+            content: {
+                decoded:
+                    'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd',
+                error: null
+            }
+        },
+        {
+            identity: 'ynet_bareminimum',
+            isAlias: false,
+            routesId: '0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d',
+            rootDirId: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
+        }
+    ]
+];
+
+describe('name service > registry', () => {
+    test.each(testCases)('parses a domain registry into Point domain data', (reg, expected) => {
+        expect(parseDomainRegistry(reg)).toEqual(expected);
+    });
+});

--- a/src/name_service/registry.ts
+++ b/src/name_service/registry.ts
@@ -1,0 +1,26 @@
+import {DomainRegistry, PointDomainData} from './types';
+import {parseCookieString} from '../util';
+
+/**
+ * Parses a registry obtained from SNS or ENS and returns
+ * Point related information associated to said domain.
+ */
+export function parseDomainRegistry(registry: DomainRegistry): PointDomainData {
+    const values = parseCookieString(registry.content.decoded ?? '');
+
+    // If the registry has a `pn_alias`, it means we need to redirect
+    // all requests to the `.sol` domain to the `.point` alias.
+    if (values['pn_alias']) {
+        return {identity: values['pn_alias'], isAlias: true};
+    }
+
+    // The registry does not have a `pn_alias`, which means we need to fetch
+    // the content using the routes ID and root directory ID stored in the
+    // domain registry.
+    return {
+        identity: values['pn_id'] || '',
+        isAlias: false,
+        routesId: values['pn_routes'] || '',
+        rootDirId: values['pn_root'] || ''
+    };
+}

--- a/src/name_service/types.ts
+++ b/src/name_service/types.ts
@@ -1,0 +1,17 @@
+export type PointDomainData = {
+    identity: string;
+    isAlias: boolean;
+    routesId?: string;
+    rootDirId?: string;
+};
+
+export type DomainContent = {
+    decoded: string | null;
+    error: Error | null;
+    protocolType?: string;
+};
+
+export type DomainRegistry = {
+    owner: string;
+    content: DomainContent;
+};

--- a/src/network/providers/solana.ts
+++ b/src/network/providers/solana.ts
@@ -3,6 +3,7 @@ import {getHashedName, getNameAccountKey, NameRegistryState} from '@solana/spl-n
 import {getSolanaKeyPair} from '../../wallet/keystore';
 import config from 'config';
 import axios from 'axios';
+import {DomainRegistry} from '../../name_service/types';
 const logger = require('../../core/log');
 const log = logger.child({module: 'SolanaProvider'});
 
@@ -31,38 +32,6 @@ interface TransactionInstructionJSON {
     }[];
     programId: string;
     data: number[];
-}
-
-enum Protocol {
-    IPFS = 'ipfs',
-    ARWV = 'arwv'
-}
-
-type DomainContent = {
-    protocolType: Protocol | null;
-    decoded: string | null;
-    error?: Error;
-};
-
-type DomainRegistry = {
-    owner: string;
-    content: DomainContent;
-};
-
-function parseContent(content: string | undefined): DomainContent {
-    if (!content) {
-        return {protocolType: null, decoded: null};
-    }
-
-    const supportedProtocols = Object.values(Protocol);
-    const protocol = supportedProtocols.find(p => content.startsWith(`${p}=`));
-    if (!protocol) {
-        return {protocolType: null, decoded: content};
-    }
-
-    // Get rid of the protocol (including the `=` sign)
-    const decoded = content.substring(protocol.length + 1);
-    return {protocolType: protocol, decoded};
 }
 
 const createSolanaConnection = (blockchainUrl: string) => {
@@ -240,7 +209,7 @@ const solana = {
 
         return {
             owner: registry.owner.toBase58(),
-            content: parseContent(content)
+            content: {decoded: content || null, error: null}
         };
     }
 };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -10,3 +10,4 @@ export * from './merkle';
 export * from './hashFn';
 export * from './escapeString';
 export * from './getReferralCode';
+export * from './parseCookieString';

--- a/src/util/parseCookieString.test.ts
+++ b/src/util/parseCookieString.test.ts
@@ -1,0 +1,31 @@
+import {parseCookieString} from './parseCookieString';
+
+type TestCase = [string, Record<string, string>];
+
+const testCases: TestCase[] = [
+    ['key=value', {key: 'value'}],
+    ['a=b;c=d;e=f;', {a: 'b', c: 'd', e: 'f'}],
+    ['ipfs=some-cid;pn_alias=ynet_blog', {ipfs: 'some-cid', pn_alias: 'ynet_blog'}],
+    [';key=value', {key: 'value'}],
+    ['key=value;', {key: 'value'}],
+    ['', {}],
+    ['a;c=d;e=f;', {c: 'd', e: 'f'}],
+    ['my-key=value', {'my-key': 'value'}],
+    ['in;valid', {}],
+    ['no_equals_sign', {}],
+    [
+        'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd',
+        {
+            ipfs: 'QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn',
+            pn_id: 'ynet_bareminimum',
+            pn_routes: '0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d',
+            pn_root: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
+        }
+    ]
+];
+
+describe('parseCookieString', () => {
+    test.each(testCases)('parses %s into an object', (str, expected) => {
+        expect(parseCookieString(str)).toEqual(expected);
+    });
+});

--- a/src/util/parseCookieString.ts
+++ b/src/util/parseCookieString.ts
@@ -1,0 +1,23 @@
+/**
+ * Converts a "cookie string" into an object.
+ *
+ * Example of cookie string:
+ *     key1=value1;key2=value2;key3=value3
+ */
+export function parseCookieString(str: string): Record<string, string> {
+    const pairs = str.split(';');
+    const map: Record<string, string> = {};
+
+    pairs.forEach(pair => {
+        const keyvalue = pair.split('=');
+        if (keyvalue.length === 2) {
+            const k = typeof keyvalue[0] === 'string' && keyvalue[0].trim();
+            const v = typeof keyvalue[1] === 'string' && keyvalue[1].trim();
+            if (k && v) {
+                map[k] = v;
+            }
+        }
+    });
+
+    return map;
+}


### PR DESCRIPTION
This is one part of the "Support SNS and ENS" feature. Here, we're adding support for `.sol` domains.

Proxy can understand and resolve `.sol` domains in two different ways:

1. The `.sol` domain has all the required information in its registry, the identity, the routes ID and the root directory ID. This option will only be available for sites that do not have smart contracts.
2. The `.sol` domain is an alias to a `.point` domain. In this case, the Solana domain registry only stores the point alias, and Proxy uses it to retrieve all the required information, as with any other `.point` domain.

[Here's an example of the first scenario](https://drive.google.com/file/d/1-Eg0dxdJ7p2MSCr5lwdk_E5-VHY42Yze/view?usp=sharing).

[And here's an example of the second one](https://drive.google.com/file/d/1UW29EjnkIx_6WAbIUmQHVOmmJDUpWdOz/view?usp=sharing).