### PR TITLE
Add SubjectAltName to all generated domain certificates

### DIFF
--- a/src/client/proxy/certificates.js
+++ b/src/client/proxy/certificates.js
@@ -42,6 +42,45 @@ function generateCertificate(servername) {
     ];
     cert.setSubject(attrs);
     cert.setIssuer(caCert.subject.attributes);
+    cert.setExtensions(
+        [
+            {
+                name: 'basicConstraints',
+                critical: true,
+                cA: false
+            },
+            // {
+            //   name: 'keyUsage',
+            //   critical: true,
+            //   digitalSignature: true,
+            //   contentCommitment: true,
+            //   keyEncipherment: true,
+            //   dataEncipherment: true,
+            //   keyAgreement: true,
+            //   keyCertSign: true,
+            //   cRLSign: true,
+            //   encipherOnly: true,
+            //   decipherOnly: true
+            // },
+            {
+                name: 'subjectAltName',
+                altNames: [{
+                    type: 2,
+                    value: servername
+                }]
+            },
+            {name: 'subjectKeyIdentifier'},
+            {
+                name: 'extKeyUsage',
+                serverAuth: true,
+                clientAuth: true,
+                codeSigning: true,
+                emailProtection: true,
+                timeStamping: true
+            },
+            {name: 'authorityKeyIdentifier'}
+        ]
+    );
     // cert.sign(keys.privateKey);
     cert.sign(privateCAKey);
 

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -244,7 +244,7 @@ const getHttpRequestHandler = (ctx: any) => async (req: FastifyRequest, res: Fas
             }
         } else {
             if (host){
-                res.header('content-type', 'text/html');
+                res.status(404).header('content-type', 'text/html');
                 return templateManager.render(Template.WEB2LINK, {url: host});
             }
             res.status(404).send('Not Found');

--- a/tests/docker/proxy-storage.spec.js
+++ b/tests/docker/proxy-storage.spec.js
@@ -107,8 +107,8 @@ describe('Storage requests through proxy', () => {
             expect(res.status).toEqual(200);
             expect(res.data).toMatch(/^<html>/);
             expect(res.data).toMatch(`<h1>Index of ${dirId}</h1>`);
-            expect(res.data).toMatch('sample-image-2.jpg;');
-            expect(res.data).toMatch('sample-image-3.jpg;');
+            expect(res.data).toMatch('sample-image-2.jpg');
+            expect(res.data).toMatch('sample-image-3.jpg');
         },
         TIMEOUTS.MD
     );


### PR DESCRIPTION
SAN is a requirement for certs since 2016
But apparently it wasn't enforce for private root certs in Firefox, until now in v101 when it started to break
This fix should stop the warnings