### PR TITLE
Prevent showing 5xx server errors

### DIFF
--- a/src/api/controllers/PointSDKController.js
+++ b/src/api/controllers/PointSDKController.js
@@ -26,7 +26,7 @@ class PointSDKController {
 
     _status(statusCode) {
         if (!Number.isNaN(Number(statusCode))) {
-            this.status = statusCode;
+            this.status = statusCode >= 500 ? 400 : statusCode;
         }
         return this;
     }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,7 @@
 const fastify = require('fastify');
 const fastifyWs = require('fastify-websocket');
 const config = require('config');
+const {transformErrorResp} = require('../errors');
 const logger = require('../core/log');
 const log = logger.child({module: 'ApiServer'});
 
@@ -46,6 +47,8 @@ class ApiServer {
             });
 
             this.server.setNotFoundHandler(this.server.notFound);
+
+            this.server.addHook('onSend', transformErrorResp);
 
             await this.server.listen(parseInt(this.config.port), this.config.address, async err => {
                 if (err) {

--- a/src/client/proxy/index.ts
+++ b/src/client/proxy/index.ts
@@ -11,29 +11,33 @@ import fastifyUrlData from '@fastify/url-data';
 import fastifyMultipart from '@fastify/multipart';
 import fastifyFormBody from '@fastify/formbody';
 import fastifyWs from 'fastify-websocket';
+import {transformErrorResp} from '../../errors';
 
 const log = logger.child({module: 'Proxy'});
 const PROXY_PORT = Number(config.get('zproxy.port'));
 const httpsServer = Fastify({
     serverFactory(handler) {
-        const server = https.createServer({
-            SNICallback: (servername, cb) => {
-                const certData = certificates.getCertificate(servername);
-                const ctx = tls.createSecureContext(certData);
+        const server = https.createServer(
+            {
+                SNICallback: (servername, cb) => {
+                    const certData = certificates.getCertificate(servername);
+                    const ctx = tls.createSecureContext(certData);
 
-                if (!ctx) {
-                    log.debug({servername}, `Not found SSL certificate for host`);
-                } else {
-                    log.debug({servername}, `SSL certificate has been found and assigned`);
+                    if (!ctx) {
+                        log.debug({servername}, `Not found SSL certificate for host`);
+                    } else {
+                        log.debug({servername}, `SSL certificate has been found and assigned`);
+                    }
+
+                    if (typeof cb !== 'function') {
+                        return ctx;
+                    }
+
+                    cb(null, ctx);
                 }
-
-                if (typeof cb !== 'function') {
-                    return ctx;
-                }
-
-                cb(null, ctx);
-            }
-        }, handler);
+            },
+            handler
+        );
 
         server.on('error', e => log.error(e, 'HTTPS server error:'));
 
@@ -47,6 +51,8 @@ httpsServer.register(fastifyMultipart);
 httpsServer.register(fastifyFormBody);
 httpsServer.register(fastifyWs);
 
+httpsServer.addHook('onSend', transformErrorResp);
+
 // Redirects http to https to the same host
 const redirectToHttpsHandler: RequestListener = function(request, response) {
     // Redirect to https
@@ -57,13 +63,13 @@ const redirectToHttpsHandler: RequestListener = function(request, response) {
 };
 
 const redirectToHttpsServer = http.createServer(redirectToHttpsHandler);
-redirectToHttpsServer.on('error', (err) => log.error(err, 'redirectToHttpsServer Error:'));
+redirectToHttpsServer.on('error', err => log.error(err, 'redirectToHttpsServer Error:'));
 redirectToHttpsServer.on('connect', (req, cltSocket, head) => {
     // connect to an origin server
     const srvSocket = net.connect(PROXY_PORT, 'localhost', () => {
-        cltSocket.write('HTTP/1.1 200 Connection Established\r\n' +
-            'Proxy-agent: Node.js-Proxy\r\n' +
-            '\r\n');
+        cltSocket.write(
+            'HTTP/1.1 200 Connection Established\r\n' + 'Proxy-agent: Node.js-Proxy\r\n' + '\r\n'
+        );
         srvSocket.write(head);
         srvSocket.pipe(cltSocket);
         cltSocket.pipe(srvSocket);

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './transformErrorResp';

--- a/src/errors/transformErrorResp.ts
+++ b/src/errors/transformErrorResp.ts
@@ -1,0 +1,19 @@
+import {onSendHookHandler} from 'fastify';
+
+/**
+ * Overrides 5xx error codes as they refer to "server errors"
+ * and the concept of "server" is misleading in Web3.
+ * Also, replace the word "server" in error messages.
+ */
+export const transformErrorResp: onSendHookHandler<unknown> = (_req, res, payload, done) => {
+    if (res.statusCode >= 500) {
+        res.code(400);
+    }
+
+    if (typeof payload === 'string') {
+        const updatedPayload = payload.replace(/server/gi, 'core');
+        done(null, updatedPayload);
+    } else {
+        done();
+    }
+};


### PR DESCRIPTION
Avoid propagating 5xx errors.

The most consistent and easiest way to do this that I found, without getting into a medium to large refactor, is to use Fastify's `onSend` hook to check and override error codes and messages.

I had to use `onSend` instead of other error-handling mechanisms provided by Fastify to be able to capture the situation where we explicitly call `res.status(5xx).send(...)`.

With these changes, we ensure that we do not send a 5xx error when an error is thrown, nor when `res.status(5xx).send(...)` is called.

I decided to override all 5xx errors, not just 500, as all errors in that range refer to "server errors". They are changed to 400. If you prefer a different status code, please let me know.

As potential improvement for the future, I think we could rely more on Fastify to catch errors, and leverage the `onError` and `setErrorHandler` to unify the way we deal with errors, including logging. Instead of using so many try/catch's where we end up sending error responses from many different places.