### PR TITLE
Add ability for proxy to resolve `.eth` domains

### DIFF
--- a/src/name_service/registry.test.ts
+++ b/src/name_service/registry.test.ts
@@ -7,25 +7,21 @@ const owner = 'blockchain_address-not_important_for_these_tests';
 
 const testCases: TestCase[] = [
     [
-        {owner, content: {decoded: 'ipfs=cid', error: null}},
+        {owner, content: 'ipfs=cid'},
         {identity: '', isAlias: false, rootDirId: '', routesId: ''}
     ],
     [
-        {owner, content: {decoded: 'ipfs=cid;pn_alias=ynet_blog', error: null}},
+        {owner, content: 'ipfs=cid;pn_alias=ynet_blog'},
         {identity: 'ynet_blog', isAlias: true}
     ],
     [
-        {owner, content: {decoded: 'pn_alias=ynet_blog;arwv=chunkId', error: null}},
+        {owner, content: 'pn_alias=ynet_blog;arwv=chunkId'},
         {identity: 'ynet_blog', isAlias: true}
     ],
     [
         {
             owner,
-            content: {
-                decoded:
-                    'email=a@b.c;pn_id=ynet_blog;pn_root=root-chunk-id;pn_routes=routes-chunk-id',
-                error: null
-            }
+            content: 'email=a@b.c;pn_id=ynet_blog;pn_root=root-chunk-id;pn_routes=routes-chunk-id'
         },
         {
             identity: 'ynet_blog',
@@ -37,11 +33,8 @@ const testCases: TestCase[] = [
     [
         {
             owner,
-            content: {
-                decoded:
-                    'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd',
-                error: null
-            }
+            content:
+                'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
         },
         {
             identity: 'ynet_bareminimum',

--- a/src/name_service/registry.ts
+++ b/src/name_service/registry.ts
@@ -6,7 +6,7 @@ import {parseCookieString} from '../util';
  * Point related information associated to said domain.
  */
 export function parseDomainRegistry(registry: DomainRegistry): PointDomainData {
-    const values = parseCookieString(registry.content.decoded ?? '');
+    const values = parseCookieString(registry.content ?? '');
 
     // If the registry has a `pn_alias`, it means we need to redirect
     // all requests to the `.sol` domain to the `.point` alias.

--- a/src/name_service/types.ts
+++ b/src/name_service/types.ts
@@ -5,13 +5,7 @@ export type PointDomainData = {
     rootDirId?: string;
 };
 
-export type DomainContent = {
-    decoded: string | null;
-    error: Error | null;
-    protocolType?: string;
-};
-
 export type DomainRegistry = {
     owner: string;
-    content: DomainContent;
+    content: string | null;
 };

--- a/src/network/providers/solana.ts
+++ b/src/network/providers/solana.ts
@@ -209,7 +209,7 @@ const solana = {
 
         return {
             owner: registry.owner.toBase58(),
-            content: {decoded: content || null, error: null}
+            content: content || null
         };
     }
 };


### PR DESCRIPTION
Works in the same way as SNS, but with a slight difference given the structure of Solana domains vs Ethereum domains.

In ENS, there are text records available, so, instead of storing the Point data in the `content`, we use a text record with a key of `point`.

There are two options:

1. have all the information in the ENS registry
2. have just an alias to a Point domain in the ENS registry

To test number 1, add a text record to your domain with a key of `point`, the value should be a Point identity, a routes ID and a root dir ID, in the following format: `pn_id=identity;pn_routes=hash-id-of-routes-file;pn_root=hash-id-of-root-dir-file`.

To test number 2, add a text record to your domain with a key of `point`, the value should be an alias to a Point identity, for example: `pn_alias=ynet_blog`.

You can register and manage a domain [here](https://app.ens.domains/). I have registered `germandv.eth` in Rinkeby, which currently holds an alias to `ynet_blog`.