### PR TITLE
Fixing metatada override

### DIFF
--- a/src/client/zweb/deployer/index.js
+++ b/src/client/zweb/deployer/index.js
@@ -289,15 +289,13 @@ class Deployer {
                             } else {
                                 log.debug('upgradeProxy call');
                                 //restore from blockchain upgradable contracts and proxy metadata if does not exist.
-                                if (!fs.existsSync(proxyMetadataFilePath)) {
-                                    if (!fs.existsSync('./.openzeppelin')) {
-                                        fs.mkdirSync('./.openzeppelin');
-                                    }
-                                    fs.writeFileSync(
-                                        proxyMetadataFilePath,
-                                        await storage.getFile(proxyDescriptionFileId)
-                                    );
+                                if (!fs.existsSync('./.openzeppelin')) {
+                                    fs.mkdirSync('./.openzeppelin');
                                 }
+                                fs.writeFileSync(
+                                    proxyMetadataFilePath,
+                                    await storage.getFile(proxyDescriptionFileId)
+                                );
 
                                 proxy = await hre.upgrades.upgradeProxy(proxyAddress, contractF);
                             }


### PR DESCRIPTION
Metadata file of upgradable plugin was not being overwritten when the file already exists. This caused problems to find the right address of the proxy. Now metadata file will be override by arweave version always. 

