### PR TITLE
Enable force-deploy-proxy option

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -27,7 +27,8 @@ declare global {
         deploy?: string,
         deploy_contracts?: boolean,
         dev?: boolean,
-        upload?: string
+        upload?: string,
+        force_deploy_proxy?: boolean
     };
 
     type CtxType = Record<string, unknown> & {

--- a/src/api/controllers/DeployController.js
+++ b/src/api/controllers/DeployController.js
@@ -13,12 +13,13 @@ class DeployController {
             this.request.query.deploy_contracts === 'true' ||
             this.request.query.deploy_contracts === '1';
         const dev = this.request.query.dev === 'true' || this.request.query.dev === '1';
+        const force_deploy_proxy = this.request.query.force_deploy_proxy === 'true' || this.request.query.force_deploy_proxy === '1';
         if (deploy_path.length === 0) throw new Error('error: deploy path not specified');
-
+        
         try {
             const Deployer = require('../../client/zweb/deployer');
             this.deployer = new Deployer(this.ctx);
-            await this.deployer.deploy(deploy_path, deploy_contracts, dev);
+            await this.deployer.deploy(deploy_path, deploy_contracts, dev, force_deploy_proxy);
             return {status: 'success'};
         } catch (e) {
             log.error(e, 'DeployController.deploy error');

--- a/src/client/zweb/deployer/index.js
+++ b/src/client/zweb/deployer/index.js
@@ -96,7 +96,7 @@ class Deployer {
         return path.join('.', manifestDir, `${name}.json`);
     }
 
-    async deploy(deployPath, deployContracts = false, dev = false) {
+    async deploy(deployPath, deployContracts = false, dev = false, force_deploy_proxy = false) {
         // todo: error handling, as usual
         const deployConfigFilePath = path.join(deployPath, 'point.deploy.json');
         const deployConfigFile = fs.readFileSync(deployConfigFilePath, 'utf-8');
@@ -282,7 +282,7 @@ class Deployer {
 
                             let proxy;
                             const contractF = await hre.ethers.getContractFactory(contractName);
-                            if (proxyAddress == null || proxyDescriptionFileId == null) {
+                            if (proxyAddress == null || proxyDescriptionFileId == null || force_deploy_proxy) {
                                 log.debug('deployProxy call');
                                 const cfg = {kind: 'uups'};
                                 proxy = await hre.upgrades.deployProxy(contractF, [], cfg);

--- a/src/core/deploy.js
+++ b/src/core/deploy.js
@@ -4,8 +4,7 @@ const logger = require('./log');
 const log = logger.child({module: 'Deploy'});
 
 class Deploy {
-    async deploy(deploy_path, deploy_contracts = false, dev = false) {
-
+    async deploy(deploy_path, deploy_contracts = false, dev = false, force_deploy_proxy = false) {
         const deploy_path_absolute = path.resolve(deploy_path);
         if (!deploy_path_absolute) {
             throw new Error('invalid path');
@@ -15,7 +14,8 @@ class Deploy {
             'deploy',
             'deploy_path=' + deploy_path_absolute,
             'deploy_contracts=' + (deploy_contracts ? 'true' : 'false'),
-            'dev=' + (dev ? 'true' : 'false')
+            'dev=' + (dev ? 'true' : 'false'),
+            'force_deploy_proxy=' + (force_deploy_proxy ? 'true' : 'false')
         );
         if (result.error) {
             log.error(result, 'Deploy error');

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,11 @@ program
         program.deploy = path;
         program.deploy_contracts = Boolean(cmd.contracts);
         program.dev = Boolean(cmd.dev);
+        program.force_deploy_proxy = Boolean(cmd.forceDeployProxy);
     })
     .option('--contracts', '(re)deploy contracts too', false)
-    .option('--dev', 'deploy zapp to dev too', false);
+    .option('--dev', 'deploy zapp to dev too', false)
+    .option('--force-deploy-proxy', 'Force the replacement of the proxy on upgradable contracts', false);
 program
     .command('upload <path>')
     .description('uploads a file or directory')
@@ -84,7 +86,6 @@ program
 // program.option('--shutdown', 'sends the shutdown signal to the daemon'); // todo
 // program.option('--daemon', 'sends the daemon to the background'); // todo
 // program.option('--rpc <method> [params]', 'send a command to the daemon'); // todo
-
 program.parse(process.argv);
 
 // ------------------ Patch Config ------------ //
@@ -136,7 +137,7 @@ if (program.deploy) {
     const Deploy = require('./core/deploy');
     const deploy = new Deploy();
     deploy
-        .deploy(program.deploy, program.deploy_contracts, program.dev)
+        .deploy(program.deploy, program.deploy_contracts, program.dev, program.force_deploy_proxy)
         .then(ctx.exit)
         .catch(ctx.die);
     // @ts-ignore


### PR DESCRIPTION
Enable to use the option --force-deploy-proxy to force the replacement of the proxy on upgradable contracts deployment. 