### PR TITLE
Extend IKV with @@copy_from_ikv= instruction

### DIFF
--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -195,7 +195,7 @@ const getHttpRequestHandler = (ctx: any) => async (req: FastifyRequest, res: Fas
             }
 
             // Download info about root dir
-            const rootDirId = await blockchain.getKeyValue(host, '::rootDir', version);
+            const rootDirId = await blockchain.getKeyValue(host, '::rootDir', version, 'exact', true);
             if (!rootDirId) {
                 // TODO: or 404 here?
                 throw new Error(`Root dir id not found for host ${host}`);

--- a/src/client/zweb/deployer/index.js
+++ b/src/client/zweb/deployer/index.js
@@ -310,7 +310,11 @@ class Deployer {
 
                             let proxy;
                             const contractF = await hre.ethers.getContractFactory(contractName);
-                            if (proxyAddress == null || proxyDescriptionFileId == null || force_deploy_proxy) {
+                            if (
+                                proxyAddress == null
+                                || proxyDescriptionFileId == null
+                                || force_deploy_proxy
+                            ) {
                                 log.debug('deployProxy call');
                                 const cfg = {kind: 'uups'};
                                 proxy = await hre.upgrades.deployProxy(contractF, [], cfg);
@@ -436,11 +440,15 @@ class Deployer {
         await this.updateCommitSha(target, deployPath, version);
 
         if (deployConfig.hasOwnProperty('pointSDKVersion')){
-            await this.updatePointVersionTag(target, POINT_SDK_VERSION, deployConfig.pointSDKVersion, version);
+            await this.updatePointVersionTag(
+                target, POINT_SDK_VERSION, deployConfig.pointSDKVersion, version
+            );
         }
 
         if (deployConfig.hasOwnProperty('pointNodeVersion')){
-            await this.updatePointVersionTag(target, POINT_NODE_VERSION, deployConfig.pointNodeVersion, version);
+            await this.updatePointVersionTag(
+                target, POINT_NODE_VERSION, deployConfig.pointNodeVersion, version
+            );
         }
 
         log.info('Deploy finished');

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -554,7 +554,7 @@ ethereum.getKeyValue = async (
         } else {
             // the format is:
             // @@copy_from_ikv=<identity>:<key_in_ikv>
-            const withoutPrefix = rootDirId.substring(copyFromIkv_prolog.length);
+            const withoutPrefix = value.substring(copyFromIkv_prolog.length);
 
             const copy_identity = withoutPrefix.split(':')[0];
             const copy_key = withoutPrefix.split(':').slice(1).join(':');

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -15,6 +15,7 @@ const log = logger.child({module: 'EthereumProvider'});
 const {getNetworkPrivateKey, getNetworkAddress} = require('../../wallet/keystore');
 const {statAsync, resolveHome, compileAndSaveContract, escapeString} = require('../../util');
 const {createCache} = require('../../util/cache');
+const {copy} = require("fs-extra");
 
 function isRetryableError({message}) {
     for (const code in retryableErrors) {
@@ -478,7 +479,7 @@ const zRecordCache = createCache();
 ethereum.getZRecord = async (domain, version = 'latest') => {
     domain = domain.replace('.point', ''); // todo: rtrim instead
     return zRecordCache.get(`${domain}-${ZDNS_ROUTES_KEY}-${version}`, async () => {
-        const result = await ethereum.getKeyValue(domain, ZDNS_ROUTES_KEY, version);
+        const result = await ethereum.getKeyValue(domain, ZDNS_ROUTES_KEY, version, 'exact', true);
         return result?.substr(0, 2) === '0x' ? result.substr(2) : result;
     });
 };
@@ -540,8 +541,32 @@ ethereum.getKeyValue = async (
     identity,
     key,
     version = 'latest',
-    versionSearchStrategy = 'exact'
+    versionSearchStrategy = 'exact',
+    followCopyFromIkv = false
 ) => {
+    // Process @@copy_from_ikv instruction if followCopyFromIkv is set to true
+    if (followCopyFromIkv) {
+        // self invoke to get the value first but without redirection
+        const value = ethereum.getKeyValue(identity, key, version, versionSearchStrategy, false);
+
+        const copyFromIkv_prolog = '@@copy_from_ikv=';
+        if (! value.startsWith(copyFromIkv_prolog)) {
+            return value; // no redirection
+        } else {
+            // the format is:
+            // @@copy_from_ikv=<identity>:<key_in_ikv>
+            const withoutPrefix = rootDirId.substring(copyFromIkv_prolog.length);
+
+            const copy_identity = withoutPrefix.split(':')[0];
+            const copy_key = withoutPrefix.split(':').slice(1).join(':');
+
+            const value = await ethereum.getKeyValue(copy_identity, copy_key, 'latest', 'exact', true);
+            if (!value) throw new Error(`Failed to obtain ikv value following ${copyFromIkv_prolog} instruction`);
+            return value;
+        }
+    }
+
+    // Get the value
     try {
         if (typeof identity !== 'string')
             throw Error('blockchain.getKeyValue(): identity must be a string');

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -15,7 +15,6 @@ const log = logger.child({module: 'EthereumProvider'});
 const {getNetworkPrivateKey, getNetworkAddress} = require('../../wallet/keystore');
 const {statAsync, resolveHome, compileAndSaveContract, escapeString} = require('../../util');
 const {createCache} = require('../../util/cache');
-const {copy} = require("fs-extra");
 
 function isRetryableError({message}) {
     for (const code in retryableErrors) {

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -546,7 +546,7 @@ ethereum.getKeyValue = async (
     // Process @@copy_from_ikv instruction if followCopyFromIkv is set to true
     if (followCopyFromIkv) {
         // self invoke to get the value first but without redirection
-        const value = ethereum.getKeyValue(identity, key, version, versionSearchStrategy, false);
+        const value = await ethereum.getKeyValue(identity, key, version, versionSearchStrategy, false);
 
         const copyFromIkv_prolog = '@@copy_from_ikv=';
         if (! value.startsWith(copyFromIkv_prolog)) {


### PR DESCRIPTION
Allows to use `@@copy_from_ikv=` directive in certain scenarios.

This is only enabled if in `blockchain.getKeyValue()` the argument `followCopyFromIkv` is set to true.
By default it is false, and only set to true in two places: when asking for the root directory (`::rootDir`) and routes file (`zdns/routes`)

When this feature is activated, `blockchain.getKeyValue()` doesn't just return the key result, but checks if it is a special directive prefixed with `@@copy_from_ikv=`, for instance: `@@copy_from_ikv=anotheridentity:somekeythere`. Then it parses the directive and tries to obtain ikv value for `somekeythere` from identity `anotheridentity`. This is not recursive.

If this succeeds, it returns this value instead.

This is a useful helper until we have proper UI and backend for software packs. It would allow us to set root dir id and routes file id to certain values in, let's say, `blogsoftware.point`, and any user that has a handle registered, can just do these things to set up the blog functionality:

::rootDir: `@@copy_from_ikv=blogsoftware:v0.1.*/rootDir`
zdns/routes: `@@copy_from_ikv=blogsoftware:v0.1.*/routes`

It would also allow us to do versioning and update the functionality for all websites that point to blogsoftware, but only for minor releases of 0.1 version in this case.