### PR TITLE
Support `.sol` deployments

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -82,6 +82,8 @@ network:
     # solana:
     #   type: "solana"
     #   address: "https://api.mainnet-beta.solana.com"
+    #   currency_name: "Sol"
+    #   currency_code: "SOL"
   web3_call_retry_limit: 4
   identity_contract_address: "0x1574E97F7a60c4eE518f6d7c0Fa701eff8Ab58b3"
   hardcode_default_provider: "0x3C903ADdcC954B318A5077D0f7bce44a7b9c95B1"

--- a/src/client/zweb/deployer/index.js
+++ b/src/client/zweb/deployer/index.js
@@ -444,7 +444,7 @@ class Deployer {
             const id = Date.now();
             const {result} = await solana.requestAccount(id, network);
             const solanaAddress = result.publicKey;
-            const {owner: domainOwner} = await solana.resolveDomain(target, network);
+            const {owner: domainOwner, content} = await solana.resolveDomain(target, network);
 
             if (solanaAddress !== domainOwner) {
                 const errMsg = `"${target}" is owned by ${domainOwner}, you need to transfer it to your Point Wallet (${solanaAddress}). Also, please make sure you have some SOL in your Point Wallet to cover transaction fees.`;
@@ -492,7 +492,7 @@ class Deployer {
             await solana.setDomainContent(domain, dataStr);
         } else if (service === 'ENS') {
             // we don't have to care about preExistingData in ENS as we save the data
-            // to a custom "text record", it's safe to override.
+            // to a custom "text record", it's safe to overwrite it.
             const dataStr = encodeCookieString(data);
             await blockchain.setDomainContent(domain, dataStr);
         } else {
@@ -516,11 +516,6 @@ class Deployer {
             const errMsg = 'Missing entry in point.deploy.json file. The following properties must be present in the file: version, target, keyvalue and contracts. Fill them with empty values if needed.';
             log.error({deployConfigFilePath: deployConfigFilePath}, errMsg);
             throw new Error(errMsg);
-        }
-
-        // TODO: implement `src/network/providers/solana.ts > setDomainContent` and remove this.
-        if (deployConfig.target.endsWith('.sol')) {
-            throw new Error(`SNS deployments are not supported yet, but coming soon, stay tuned.`);
         }
 
         const {target, isPointTarget, identity, isAlias} = this.getTargetAndIdentity(

--- a/src/network/providers/solana.ts
+++ b/src/network/providers/solana.ts
@@ -1,5 +1,5 @@
 import * as web3 from '@solana/web3.js';
-import {getHashedName, getNameAccountKey, NameRegistryState} from '@solana/spl-name-service';
+import {getHashedName, getNameAccountKey, NameRegistryState, updateNameRegistryData} from '@solana/spl-name-service';
 import {getSolanaKeyPair} from '../../wallet/keystore';
 import config from 'config';
 import axios from 'axios';
@@ -67,6 +67,28 @@ const instructionFromJson = (json: TransactionInstructionJSON): web3.Transaction
     programId: new web3.PublicKey(json.programId),
     data: Buffer.from(json.data)
 });
+
+/**
+ * Helper function to create a transaction from an array of instructions,
+ * sign it, and send it.
+ *
+ * The first signer in the array of signers is going to be the fee payer.
+ *
+ * Quite similar to the `solana.signAndSendTransaction` method, but more
+ * convenient to use when you already have one or more properly structured
+ * `instruction`s.
+ */
+const sendInstructions = async (
+    connection: web3.Connection,
+    signers: web3.Keypair[],
+    instructions: web3.TransactionInstruction[]
+): Promise<string> => {
+    const tx = new web3.Transaction();
+    tx.feePayer = signers[0].publicKey;
+    tx.add(...instructions);
+    const txId = await connection.sendTransaction(tx, signers, {preflightCommitment: 'single'});
+    return txId;
+};
 
 const solana = {
     requestAccount: async (id: number, network: string) => {
@@ -215,8 +237,28 @@ const solana = {
         };
     },
     setDomainContent: async(domainName: string, data: string, network = 'solana') => {
-        log.error({domainName, data, network}, 'Writing to Solana domain registry is not supported yet.');
-        throw new Error('Solana > setDomainContent has not been implemented yet');
+        const provider = providers[network];
+        if (!provider) {
+            throw new Error(`Unknown network "${network}".`);
+        }
+
+        const {connection, wallet} = provider;
+        const domain = domainName.endsWith('.sol') ? domainName.replace(/.sol$/, '') : domainName;
+        const offset = 0;
+        const buf = Buffer.from(data);
+        const buffers = [buf, Buffer.alloc(1_000 - buf.length)];
+
+        const instruction = await updateNameRegistryData(
+            provider.connection,
+            domain,
+            offset,
+            Buffer.concat(buffers),
+            undefined,
+            SOL_TLD_AUTHORITY
+        );
+
+        const txId = await sendInstructions(connection, [wallet], [instruction]);
+        return txId;
     }
 };
 


### PR DESCRIPTION
Add support for deploying dApps using Solana Name Service, in particular, using `.sol` domains.

For further details about the ENS and SNS general functionality, please refer to [this PR](https://github.com/pointnetwork/pointnetwork/pull/463).