### PR TITLE
PN-175 Support CORS in proxy server

### DIFF
--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -392,6 +392,12 @@ const getHttpRequestHandler = (ctx: any) => async (req: FastifyRequest, res: Fas
                 } catch (error) {}
 
                 if (urlMirrorUrl) {
+                    // Set CORS headers
+                    const allowedOrigin = req.headers.referer?.replace(/\/$/, '');
+                    res.header('Vary', 'Origin');
+                    res.header('Access-Control-Allow-Origin', allowedOrigin);
+
+                    // Redirect to mirror URL
                     res.redirect(urlMirrorUrl);
                     return;
                 }

--- a/src/client/proxy/httpsServer.ts
+++ b/src/client/proxy/httpsServer.ts
@@ -8,6 +8,7 @@ import fastifyMultipart from '@fastify/multipart';
 import fastifyFormBody from '@fastify/formbody';
 import fastifyWs from 'fastify-websocket';
 import {transformErrorResp} from '../../errors';
+import {cors} from './middleware';
 
 const log = logger.child({module: 'Proxy'});
 const httpsServer = Fastify({
@@ -46,6 +47,7 @@ httpsServer.register(fastifyMultipart);
 httpsServer.register(fastifyFormBody);
 httpsServer.register(fastifyWs);
 
+httpsServer.addHook('preHandler', cors);
 httpsServer.addHook('onSend', transformErrorResp);
 
 export default httpsServer;

--- a/src/client/proxy/middleware/cors.ts
+++ b/src/client/proxy/middleware/cors.ts
@@ -1,0 +1,18 @@
+import {preHandlerHookHandler} from 'fastify';
+
+/**
+ * Allows Cross-Origin Requests to `https://mirror.point`.
+ */
+export const cors: preHandlerHookHandler = (req, res, done) => {
+    const protocol = req.protocol;
+    const {host} = req.urlData();
+
+    if (`${protocol}://${host}` === 'https://mirror.point') {
+        // Requests that are a result of a redirection during a CORS request
+        // have the `Origin` header set to `null`.
+        // Hence, we allow all origins (*) for `https://mirror.point`.
+        res.header('Access-Control-Allow-Origin', '*');
+    }
+
+    done();
+};

--- a/src/client/proxy/middleware/index.ts
+++ b/src/client/proxy/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './cors';


### PR DESCRIPTION
Supporting CORS in proxy is needed to get assets from the `mirror`. Please refer to [the ticket](https://point-labs.atlassian.net/browse/PN-175) for further details.

![cors](https://user-images.githubusercontent.com/101118664/174870878-edb66ac0-839c-4b7f-8e0e-c9bc7c40809e.png)

CORS is only enabled for requests to mirror.point.

These changes only handle _simple_ requests. We may need to also support _preflight_ requests, but since I haven't came across them just yet, we could add support for them later on (however, if you want me to do it now, let me know).