### PR TITLE
Add TLS information to blockchain providers

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -68,6 +68,7 @@ network:
       address: "ynet.point.space:44444"
       currency_name: "yPoint"
       currency_code: "yPOINT"
+      tls: false
       tokens: []
     rinkeby:
       type: "eth"
@@ -75,6 +76,7 @@ network:
       currency_name: "rinkebyEth"
       currency_code: "rinkebyETH"
       eth_tld_resolver: "0xf6305c19e814d2a75429Fd637d01F7ee0E77d615"
+      tls: true
       tokens:
         - name: "USDC"
           address: "0x87284d4150b0FADe12255A7d208AD46526C519ee"
@@ -87,11 +89,13 @@ network:
       address: "api.devnet.solana.com"
       currency_name: "devSol"
       currency_code: "devSOL"
+      tls: true
     # solana:
     #   type: "solana"
     #   address: "https://api.mainnet-beta.solana.com"
     #   currency_name: "Sol"
     #   currency_code: "SOL"
+    #   tls: true
   web3_call_retry_limit: 4
   identity_contract_address: "0x1574E97F7a60c4eE518f6d7c0Fa701eff8Ab58b3"
   hardcode_default_provider: "0x3C903ADdcC954B318A5077D0f7bce44a7b9c95B1"

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -80,7 +80,7 @@ const providers = {
     }
 };
 
-const getWeb3 = ({chain = 'ynet', protocol = 'http'} = {}) => {
+const getWeb3 = ({chain = 'ynet', protocol} = {}) => {
     if (
         !Object.keys(networks)
             .filter(key => networks[key].type === 'eth')
@@ -90,6 +90,9 @@ const getWeb3 = ({chain = 'ynet', protocol = 'http'} = {}) => {
     }
     if (!providers[chain]) {
         providers[chain] = {};
+    }
+    if (!protocol) {
+        protocol = networks[chain].tls ? 'https' : 'http';
     }
     if (!providers[chain][protocol]) {
         providers[chain][protocol] = createWeb3Instance({


### PR DESCRIPTION
The goal is to instantiate the web3 providers with the proper protocol and avoid errors such as calling Infura over http instead of https.

The bug in particular that we faced is that /wallet would not load and there were errors in the logs about RPC calls expected to be HTTPS. This was happening because The provider for Rinkeby was instantiated with HTTP instead of HTTPS.

I think that it could be a good idea to keep a `tls` field in the config, to tell whether a provider is supposed to work over HTTP/WS or HTTPS/WSS. So that we don't have to pass the protocol on every invocation. But there are many ways to go about it. And I'm not too familiar with the latest work on the wallet, so please feel free to change the solution.