### PR TITLE
PF-22 Create instance of `eth.Contract` properly

### DIFF
--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -151,7 +151,8 @@ ethereum.loadPointContract = async (
                     log.debug('Successfully fetched identity contract from storage');
 
                     abisByContractName[contractName] = JSON.parse(abiFile).abi;
-                    return new getWeb3().eth.Contract(abisByContractName[contractName], at);
+                    const web3 = getWeb3();
+                    return new web3.eth.Contract(abisByContractName[contractName], at);
                 } catch (e) {
                     log.error('Failed to fetch Identity contract from storage: ' + e.message);
                 }


### PR DESCRIPTION
I didn't replicate the error exactly, but, I replaced the [last two lines](https://github.com/pointnetwork/pointnetwork/blob/68e5da84a77339cd362371c170e760b6d3489fd6/src/network/providers/ethereum.js#L173-L174) of the modified function to use:
```
return new getWeb3().eth.Contract(abisByContractName[contractName], at)
```

instead of:
```
const web3 = getWeb3();
return new web3.eth.Contract(abisByContractName[contractName], at);
```

And I got the same error. So, it should be safe to follow the same approach in both cases: first `getWeb3()` and then call `new web3.eth.Contract`.

I also tested it by intentionally throwing [here](https://github.com/pointnetwork/pointnetwork/blob/68e5da84a77339cd362371c170e760b6d3489fd6/src/network/providers/ethereum.js#L140).