### PR TITLE
Throw on start up if key.json has invalid `phrase`

### DIFF
--- a/src/initFolders.ts
+++ b/src/initFolders.ts
@@ -1,4 +1,4 @@
-import {resolveHome, makeSurePathExists} from './util';
+import {resolveHome, makeSurePathExists, makeSureKeyfileHasPhrase} from './util';
 import path from 'path';
 import config from 'config';
 
@@ -8,19 +8,25 @@ const initFolders = async () => {
     try {
         await makeSurePathExists(datadir);
     } catch (e) {
-        throw new Error('Datadir folder does not exist. Did you create it? Please, refer to this guide: https://github.com/pointnetwork/pointnetwork-dashboard/blob/main/ALPHA.md');
+        throw new Error(
+            'Datadir folder does not exist. Did you create it? Please, refer to this guide: https://github.com/pointnetwork/pointnetwork-dashboard/blob/main/ALPHA.md'
+        );
     }
 
     try {
         await makeSurePathExists(keystore);
     } catch (e) {
-        throw new Error('Keystore folder does not exist. Did you create it? Please, refer to this guide: https://github.com/pointnetwork/pointnetwork-dashboard/blob/main/ALPHA.md');
+        throw new Error(
+            'Keystore folder does not exist. Did you create it? Please, refer to this guide: https://github.com/pointnetwork/pointnetwork-dashboard/blob/main/ALPHA.md'
+        );
     }
 
     try {
-        await makeSurePathExists(path.join(keystore, 'key.json'));
+        await makeSureKeyfileHasPhrase(path.join(keystore, 'key.json'));
     } catch (e) {
-        throw new Error('key.json file does not exist. Did you create it? Please, refer to this guide: https://github.com/pointnetwork/pointnetwork-dashboard/blob/main/ALPHA.md');
+        throw new Error(
+            'key.json file does not exist or is invalid. Please, refer to this guide: https://github.com/pointnetwork/pointnetwork-dashboard/blob/main/ALPHA.md'
+        );
     }
 
     const nestedFolders = [

--- a/src/util/makeSurePathExists.ts
+++ b/src/util/makeSurePathExists.ts
@@ -12,3 +12,19 @@ export const makeSurePathExists = async (pathToCheck: string, createIfNotExists 
         }
     }
 };
+
+/**
+ * Reads the `key.json` file, parses it and validates that it has a
+ * `phrase` key with a 12-word string. It throws if it does not.
+ */
+export const makeSureKeyfileHasPhrase = async (filepath: string) => {
+    try {
+        const str = await fs.readFile(filepath, 'utf8');
+        const {phrase} = JSON.parse(str);
+        if (!phrase || phrase.split(/\s/g).length !== 12) {
+            throw new Error(`${filepath} has a missing or invalid "phrase".`);
+        }
+    } catch (err) {
+        throw err;
+    }
+};


### PR DESCRIPTION
The library we're using to deal with mnemonics ([bip39](https://www.npmjs.com/package/bip39)), accepts an empty string as valid input, and it generates a seed from it, which we then use to create an HD Wallet with another library (ethereumjs-wallet).

For context, the steps are:
```javascript
const mnemonic = readFromKeyfile();
const seed = bip39.mnemonicToSeedSync(mnemonic);
const hdwallet = hdkey.fromMasterSeed(seed);
const wallet = hdwallet.getWallet();
```

Since an empty string is treated as a valid mnemonic, it always generates the same key. In `ynet`, this key has been used to register the identity `ynet_u`.

bip39 kind of mentions in their README that it's the developer's responsibility to check the validity of the mnemonic:

> However, there should be other checks in place, such as checking to make sure the user is inputting 12 words or more

There's an [open issue](https://github.com/bitcoinjs/bip39/issues/77) (with no activity since 2018), where they discuss whether there should be some checks or not when it comes to getting a seed from a mnemonic. Although the issue is still open, it looks like they decided that it's the developer's and not the library's responsibility to do such sanity checks.

Following the current approach of throwing an error when `key.json` is not present, I decided to also throw in the same step if `key.json` does not include a `phrase` key with a 12-word string as its value.
