### PR TITLE
Deploy from dapp folder

### DIFF
--- a/.bash_alias
+++ b/.bash_alias
@@ -12,7 +12,18 @@ alias point-visit="NODE_CONFIG_ENV=visitlocal MODE=zappdev npm run watch"
 alias point-dev-use-oracle="NODE_CONFIG_ENV=devlocal MODE=zappdev USE_ORACLE=true npm run watch"
 alias point-visit-use-oracle="NODE_CONFIG_ENV=visitlocal MODE=zappdev USE_ORACLE=true npm run watch"
 
-alias point-deploy="NODE_CONFIG_ENV=devlocal MODE=zappdev ./point deploy "
+export POINT_PATH=$(realpath .)
+
+point-deploy(){
+    local CURRENT_PATH=$(realpath .)
+    if [[ "$CURRENT_PATH" == "$POINT_PATH" ]]; then
+        NODE_CONFIG_ENV=devlocal MODE=zappdev ./point deploy "$@"
+    else
+        cd $POINT_PATH
+        NODE_CONFIG_ENV=devlocal MODE=zappdev ./point deploy $CURRENT_PATH "$@"
+        cd $CURRENT_PATH
+    fi;
+}
 
 alias point-dev-install="./scripts/create-local-env.sh"
 alias point-dev-start="./scripts/start-local.sh"

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "outputPath": "bin",
     "assets": [
       "package.json",
+      "hardhat.config.js",
       "hardhat/**/*",
       "config/*.yaml",
       "migrations/**/*",

--- a/point
+++ b/point
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-var path = require("path");
+var path = require('path');
 
 let prepare = '';
-if(process.argv.length >= 4 && process.argv[2] === 'deploy'){
-    prepare = 'cd ' + process.argv[1].slice(0, process.argv[1].length -6) + " && ";
+if (process.argv.length >= 4 && process.argv[2] === 'deploy'){
+    prepare = 'cd ' + process.argv[1].slice(0, process.argv[1].length - 6) + ' && ';
     const absolutePath = path.resolve(process.argv[3]);
     process.argv[3] = absolutePath;
 }

--- a/point
+++ b/point
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
+var path = require("path");
+
+let prepare = '';
+if(process.argv.length >= 4 && process.argv[2] === 'deploy'){
+    prepare = 'cd ' + process.argv[1].slice(0, process.argv[1].length -6) + " && ";
+    const absolutePath = path.resolve(process.argv[3]);
+    process.argv[3] = absolutePath;
+}
 
 require('child_process').spawnSync(
-    'npm run start --',
+    prepare + 'npm run start --',
     process.argv.slice(2),
     {stdio: 'inherit', shell: true}
 );


### PR DESCRIPTION
Allow the deployment of DApps from the DApp folder. For running use:
`point-deploy --contracts`
The folder parameter is not needed since the current folder is considered as the deployment folder.
Also can use as usual from pointnetwork folder
`point-deploy ../dapp_folder --contracts`
