### PR TITLE
PN-197 Derive Solana keypairs same as Phantom Wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "detect-content-type": "^1.2.0",
         "dockerode": "^3.3.1",
         "eccrypto": "^1.1.6",
+        "ed25519-hd-key": "^1.3.0",
         "ethereumjs-util": "^7.1.0",
         "ethereumjs-wallet": "^1.0.2",
         "fastify": "^3.20.2",
@@ -9212,6 +9213,15 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ed25519-hd-key": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ed25519-hd-key/-/ed25519-hd-key-1.3.0.tgz",
+      "integrity": "sha512-IWwAyiiuJQhgu3L8NaHb68eJxTu2pgCwxIBdgpLJdKpYZM46+AXePSVTr7fkNKaUOfOL4IrjEUaQvyVRIDP7fg==",
+      "dependencies": {
+        "create-hmac": "1.1.7",
+        "tweetnacl": "1.0.3"
       }
     },
     "node_modules/editorconfig": {
@@ -33602,6 +33612,15 @@
             "safe-buffer": "^5.1.2"
           }
         }
+      }
+    },
+    "ed25519-hd-key": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ed25519-hd-key/-/ed25519-hd-key-1.3.0.tgz",
+      "integrity": "sha512-IWwAyiiuJQhgu3L8NaHb68eJxTu2pgCwxIBdgpLJdKpYZM46+AXePSVTr7fkNKaUOfOL4IrjEUaQvyVRIDP7fg==",
+      "requires": {
+        "create-hmac": "1.1.7",
+        "tweetnacl": "1.0.3"
       }
     },
     "editorconfig": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "detect-content-type": "^1.2.0",
     "dockerode": "^3.3.1",
     "eccrypto": "^1.1.6",
+    "ed25519-hd-key": "^1.3.0",
     "ethereumjs-util": "^7.1.0",
     "ethereumjs-wallet": "^1.0.2",
     "fastify": "^3.20.2",

--- a/src/api/controllers/IdentityController.js
+++ b/src/api/controllers/IdentityController.js
@@ -1,7 +1,7 @@
 const PointSDKController = require('./PointSDKController');
 const blockchain = require('../../network/providers/ethereum');
 const solana = require('../../network/providers/solana');
-const {getNetworkPublicKey, getNetworkAddress} = require('../../wallet/keystore');
+const {getNetworkPublicKey, getNetworkAddress, getSolanaKeyPair} = require('../../wallet/keystore');
 const logger = require('../../core/log');
 const log = logger.child({Module: 'IdentityController'});
 const crypto = require('crypto');
@@ -47,9 +47,9 @@ let TwitterOracle = {
     },
 
     async confirmTwitterValidation(identity, address, url) {
-        const oracleUrl = `${twitterOracleUrl}/api/activate_tweet?handle=${identity}&address=${address}&url=${
-            encodeURIComponent(url)
-        }`;
+        const oracleUrl = `${twitterOracleUrl}/api/activate_tweet?handle=${identity}&address=${address}&url=${encodeURIComponent(
+            url
+        )}`;
 
         log.info(`calling to ${oracleUrl}`);
         const {data} = await axios.post(oracleUrl);
@@ -118,8 +118,21 @@ class IdentityController extends PointSDKController {
     }
 
     async isIdentityRegistered() {
+        // Check for `.sol` identity.
+        const solanaAccount = getSolanaKeyPair().publicKey.toString();
+
+        // Check for `.eth` identity.
+        // const ethereumAddress = getNetworkAddress();
+
+        // Check for `.point` identity.
+
         const identityRegistred = await blockchain.isCurrentIdentityRegistered();
-        return this._response({identityRegistred: identityRegistred});
+
+        return this._response({
+            identityRegistred,
+            solana: solanaAccount
+            // ethereum: ethereumAddress
+        });
     }
 
     async identityToOwner() {

--- a/src/api/controllers/IdentityController.js
+++ b/src/api/controllers/IdentityController.js
@@ -1,7 +1,7 @@
 const PointSDKController = require('./PointSDKController');
 const blockchain = require('../../network/providers/ethereum');
 const solana = require('../../network/providers/solana');
-const {getNetworkPublicKey, getNetworkAddress, getSolanaKeyPair} = require('../../wallet/keystore');
+const {getNetworkPublicKey, getNetworkAddress} = require('../../wallet/keystore');
 const logger = require('../../core/log');
 const log = logger.child({Module: 'IdentityController'});
 const crypto = require('crypto');
@@ -47,9 +47,9 @@ let TwitterOracle = {
     },
 
     async confirmTwitterValidation(identity, address, url) {
-        const oracleUrl = `${twitterOracleUrl}/api/activate_tweet?handle=${identity}&address=${address}&url=${encodeURIComponent(
-            url
-        )}`;
+        const oracleUrl = `${twitterOracleUrl}/api/activate_tweet?handle=${identity}&address=${address}&url=${
+            encodeURIComponent(url)
+        }`;
 
         log.info(`calling to ${oracleUrl}`);
         const {data} = await axios.post(oracleUrl);
@@ -118,21 +118,8 @@ class IdentityController extends PointSDKController {
     }
 
     async isIdentityRegistered() {
-        // Check for `.sol` identity.
-        const solanaAccount = getSolanaKeyPair().publicKey.toString();
-
-        // Check for `.eth` identity.
-        // const ethereumAddress = getNetworkAddress();
-
-        // Check for `.point` identity.
-
         const identityRegistred = await blockchain.isCurrentIdentityRegistered();
-
-        return this._response({
-            identityRegistred,
-            solana: solanaAccount
-            // ethereum: ethereumAddress
-        });
+        return this._response({identityRegistred: identityRegistred});
     }
 
     async identityToOwner() {

--- a/src/wallet/keystore.ts
+++ b/src/wallet/keystore.ts
@@ -7,15 +7,22 @@ import Wallet, {hdkey} from 'ethereumjs-wallet';
 import * as bip39 from 'bip39';
 import {mnemonicToSeedSync} from 'bip39';
 import {Keypair} from '@solana/web3.js';
+import {derivePath} from 'ed25519-hd-key';
 
 const keystorePath: string = resolveHome(config.get('wallet.keystore_path'));
+
+// The one used by Phantom Wallet.
+// (Solflare uses `m/44'/501'` by default, but shows this one in the advanced options)
+const SOLANA_HDWALLET_DERIVATION_PATH = `m/44'/501'/0'/0'`;
 
 function getWalletFactory() {
     let wallet: Wallet | undefined;
     let secretPhrase: string;
-    return (): { wallet: Wallet, secretPhrase: string } => {
+    return (): {wallet: Wallet; secretPhrase: string} => {
         if (!wallet) {
-            secretPhrase = JSON.parse(fs.readFileSync(path.join(keystorePath, 'key.json')).toString()).phrase;
+            secretPhrase = JSON.parse(
+                fs.readFileSync(path.join(keystorePath, 'key.json')).toString()
+            ).phrase;
             const hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeedSync(secretPhrase));
             wallet = hdwallet.getWallet();
         }
@@ -26,15 +33,21 @@ function getWalletFactory() {
 const getWallet = getWalletFactory();
 
 export function getNetworkAddress() {
-    return `0x${getWallet().wallet.getAddress().toString('hex')}`;
+    return `0x${getWallet()
+        .wallet.getAddress()
+        .toString('hex')}`;
 }
 
 export function getNetworkPublicKey() {
-    return getWallet().wallet.getPublicKey().toString('hex');
+    return getWallet()
+        .wallet.getPublicKey()
+        .toString('hex');
 }
 
 export function getNetworkPrivateKey() {
-    return getWallet().wallet.getPrivateKey().toString('hex');
+    return getWallet()
+        .wallet.getPrivateKey()
+        .toString('hex');
 }
 
 export function getSecretPhrase() {
@@ -42,8 +55,12 @@ export function getSecretPhrase() {
 }
 
 export const getSolanaKeyPair = () => {
-    const seed = mnemonicToSeedSync(getSecretPhrase());
-    return Keypair.fromSeed(Uint8Array.from(seed.toJSON().data.slice(0, 32)));
+    const phrase = getSecretPhrase();
+    const seed = mnemonicToSeedSync(phrase);
+    const keypair = Keypair.fromSeed(
+        derivePath(SOLANA_HDWALLET_DERIVATION_PATH, seed.toString('hex')).key
+    );
+    return keypair;
 };
 
 // TODO: restore if needed


### PR DESCRIPTION
Please refer to ticket [PN-197](https://point-labs.atlassian.net/browse/PN-197) for context.

With these changes, the Solana account derived by Point Engine matches the default one derived by Phantom Wallet given the same secret phrase:
![compare-address](https://user-images.githubusercontent.com/101118664/180843752-720f07fa-95bd-4008-8bea-26c2a1bad6fe.png)


**WARNING**: merging this would mean "changing" Solana accounts of existing users, as we will derive different ones from their existing secret phrases. I think this is fine in ynet and that the sooner we change it the better, but let's please analyse carefully.