### PR TITLE
PN-199 Allow deployment of SNS/ENS without a Point Identity

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -109,7 +109,8 @@ network:
       tls: true
     solana:
       type: "solana"
-      address: "api.mainnet-beta.solana.com"
+      name: "Solana"
+      http_address: "api.mainnet-beta.solana.com"
       currency_name: "Sol"
       currency_code: "SOL"
       tls: true

--- a/src/name_service/registry.test.ts
+++ b/src/name_service/registry.test.ts
@@ -21,10 +21,10 @@ const testCases: TestCase[] = [
     [
         {
             owner,
-            content: 'email=a@b.c;pn_id=ynet_blog;pn_root=root-chunk-id;pn_routes=routes-chunk-id'
+            content: 'email=a@b.c;pn_root=root-chunk-id;pn_routes=routes-chunk-id'
         },
         {
-            identity: 'ynet_blog',
+            identity: '',
             isAlias: false,
             routesId: 'routes-chunk-id',
             rootDirId: 'root-chunk-id'
@@ -34,10 +34,10 @@ const testCases: TestCase[] = [
         {
             owner,
             content:
-                'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
+                'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
         },
         {
-            identity: 'ynet_bareminimum',
+            identity: '',
             isAlias: false,
             routesId: '0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d',
             rootDirId: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'

--- a/src/name_service/registry.ts
+++ b/src/name_service/registry.ts
@@ -18,7 +18,7 @@ export function parseDomainRegistry(registry: DomainRegistry): PointDomainData {
     // the content using the routes ID and root directory ID stored in the
     // domain registry.
     return {
-        identity: values['pn_id'] || '',
+        identity: '',
         isAlias: false,
         routesId: values['pn_routes'] || '',
         rootDirId: values['pn_root'] || ''

--- a/src/util/cookieString.test.ts
+++ b/src/util/cookieString.test.ts
@@ -14,10 +14,9 @@ const parseTestCases: ParseTestCase[] = [
     ['in;valid', {}],
     ['no_equals_sign', {}],
     [
-        'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd',
+        'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd',
         {
             ipfs: 'QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn',
-            pn_id: 'ynet_bareminimum',
             pn_routes: '0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d',
             pn_root: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
         }
@@ -41,11 +40,10 @@ const encodeTestCases: EncodeTestCase[] = [
     [
         {
             ipfs: 'QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn',
-            pn_id: 'ynet_bareminimum',
             pn_routes: '0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d',
             pn_root: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
         },
-        'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_id=ynet_bareminimum;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
+        'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
     ]
 ];
 
@@ -63,17 +61,15 @@ const mergeTestCases: MergeTestCase[] = [
         {pn_alias: 'ynet_me'},
         {ipfs: 'QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn', pn_alias: 'ynet_me'}
     ],
-    ['pn_id=old-idenitity', {pn_id: 'new-identity'}, {pn_id: 'new-identity'}],
+    ['pn_alias=old-idenitity', {pn_alias: 'new-identity'}, {pn_alias: 'new-identity'}],
+    ['', {pn_routes: 'routes-id'}, {pn_routes: 'routes-id'}],
     [
-        '',
-        {pn_id: 'new-identity', pn_routes: 'routes-id'},
-        {pn_id: 'new-identity', pn_routes: 'routes-id'}
+        'a=b;pn_alias=old',
+        {pn_root: 'root-id', pn_routes: 'routes-id'},
+        {a: 'b', pn_root: 'root-id', pn_routes: 'routes-id'}
     ],
-    [
-        'a=b;pn_id=old',
-        {pn_id: 'new', pn_routes: 'routes-id'},
-        {a: 'b', pn_id: 'new', pn_routes: 'routes-id'}
-    ]
+    ['pn_root=root-id;pn_routes=routes-id', {pn_alias: 'social'}, {pn_alias: 'social'}],
+    ['pn_root=root-id;a=b;pn_routes=routes-id', {pn_alias: 'social'}, {a: 'b', pn_alias: 'social'}]
 ];
 
 describe('merge', () => {

--- a/src/util/cookieString.ts
+++ b/src/util/cookieString.ts
@@ -40,8 +40,12 @@ export function encodeCookieString(obj: Record<string, string>): string {
  * making sure not to duplicate any keys.
  */
 export function merge(old: string, obj: Record<string, string>): Record<string, string> {
-    return {
-        ...parseCookieString(old),
-        ...obj
-    };
+    const prevData = parseCookieString(old);
+
+    // Delete `point` keys to avoid inconsistencies like having a `pn_alias` together with a `pn_root`,
+    delete prevData.pn_root;
+    delete prevData.pn_routes;
+    delete prevData.pn_alias;
+
+    return {...prevData, ...obj};
 }


### PR DESCRIPTION
The main goal is to allow the deployment of simple sites (no smart contracts) to `.sol` and `.eth` targets.

Please refer to [this video](https://drive.google.com/file/d/1SJ1thzmtoHEh-mo8N5uoZkm8z-Ni1ttA/view?usp=sharing) for a quick demo and to [the ticket](https://point-labs.atlassian.net/browse/PN-199) for context.