### PR TITLE
PN-200 Decode tx input data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pointnetwork",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pointnetwork",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
@@ -24,6 +24,7 @@
         "@truffle/hdwallet-provider": "^1.5.0",
         "@typechain/ethers-v5": "^10.0.0",
         "@typechain/hardhat": "^6.0.0",
+        "abi-decoder": "^2.4.0",
         "arweave": "^1.11.4",
         "arweave-mnemonic-keys": "^0.0.9",
         "async": "^3.2.3",
@@ -5608,6 +5609,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/abi-decoder": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.4.0.tgz",
+      "integrity": "sha512-TOLU2q1HgYOjs1GKGtVzaqrYkar6I2fT9a80rzx6/9EJ/5crb4nCGuro0grZayixem93T7omrajYmLiMkYDLDA==",
+      "dependencies": {
+        "web3-eth-abi": "^1.2.1",
+        "web3-utils": "^1.2.1"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -30752,6 +30762,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "abi-decoder": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.4.0.tgz",
+      "integrity": "sha512-TOLU2q1HgYOjs1GKGtVzaqrYkar6I2fT9a80rzx6/9EJ/5crb4nCGuro0grZayixem93T7omrajYmLiMkYDLDA==",
+      "requires": {
+        "web3-eth-abi": "^1.2.1",
+        "web3-utils": "^1.2.1"
+      }
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@truffle/hdwallet-provider": "^1.5.0",
     "@typechain/ethers-v5": "^10.0.0",
     "@typechain/hardhat": "^6.0.0",
+    "abi-decoder": "^2.4.0",
     "arweave": "^1.11.4",
     "arweave-mnemonic-keys": "^0.0.9",
     "async": "^3.2.3",

--- a/src/api/sockets/ZProxySocketController.js
+++ b/src/api/sockets/ZProxySocketController.js
@@ -60,8 +60,17 @@ class ZProxySocketController {
                 }
 
                 case SUBSCRIPTION_REQUEST_TYPES.RPC: {
-                    const {method, params, id, network} = request;
-                    const {status, result} = await handleRPC({method, params, id, network});
+                    const {method, params, id, network, __hostname, meta} = request;
+
+                    const {status, result} = await handleRPC({
+                        method,
+                        params,
+                        id,
+                        network,
+                        target: __hostname,
+                        contract: meta ? meta.contract : ''
+                    });
+
                     return this.pushRPCMessage({
                         request,
                         subscriptionId: null,
@@ -88,7 +97,7 @@ class ZProxySocketController {
     }
 
     pushToClient(msg) {
-        if (this.ws && (this.ws.readyState === 1)) {
+        if (this.ws && this.ws.readyState === 1) {
             this.ws.send(JSON.stringify(msg));
         }
     }

--- a/src/rpc/decode.test.ts
+++ b/src/rpc/decode.test.ts
@@ -1,0 +1,53 @@
+import {ABITracker} from './decode';
+
+let abiTracker: ABITracker;
+beforeEach(() => (abiTracker = new ABITracker(500)));
+
+const sleep = (timeout: number) => new Promise(resolve => setTimeout(resolve, timeout));
+
+describe('Decode Tx Input Data', () => {
+    it('should add two entries', () => {
+        abiTracker.add('social', 'PointSocial');
+        abiTracker.add('email', 'PointEmail');
+
+        expect.assertions(3);
+        expect(abiTracker.has('social', 'PointSocial')).toBe(true);
+        expect(abiTracker.has('email', 'PointEmail')).toBe(true);
+        expect(abiTracker.len()).toEqual(2);
+    });
+
+    it('should not add duplicate entries', () => {
+        abiTracker.add('social', 'PointSocial');
+        abiTracker.add('social', 'PointSocial');
+        abiTracker.add('social', 'PointSocial');
+
+        expect.assertions(1);
+        expect(abiTracker.len()).toEqual(1);
+    });
+
+    it('should return false when entry does not exist', () => {
+        expect.assertions(1);
+        expect(abiTracker.has('new', 'SomeContract')).toBe(false);
+    });
+
+    it('should delete an expired entry', async () => {
+        abiTracker.add('social', 'PointSocial');
+
+        expect.assertions(3);
+        expect(abiTracker.has('social', 'PointSocial')).toBe(true);
+        await sleep(1_000);
+        expect(abiTracker.has('social', 'PointSocial')).toBe(false);
+        expect(abiTracker.len()).toEqual(0);
+    });
+
+    it('should overwrite older entry', async () => {
+        abiTracker.add('social', 'PointSocial');
+        await sleep(300);
+        abiTracker.add('social', 'PointSocial');
+        await sleep(300);
+
+        expect.assertions(2);
+        expect(abiTracker.has('social', 'PointSocial')).toBe(true);
+        expect(abiTracker.len()).toEqual(1);
+    });
+});

--- a/src/rpc/decode.ts
+++ b/src/rpc/decode.ts
@@ -1,0 +1,46 @@
+const abiDecoder = require('abi-decoder');
+import ethereum from '../network/providers/ethereum';
+
+type Param = {
+    name: string;
+    value: string;
+    type: string;
+};
+
+type DecodedTxInput = {
+    name: string;
+    params: Param[];
+};
+
+// A map to keep track of which ABIs have been added, to avoid duplicates.
+const addedABIs: Record<string, boolean> = {};
+
+/**
+ * Decode Tx and return human-readable input data.
+ */
+export async function decodeTxInputData(
+    target: string | undefined,
+    contract: string | undefined,
+    params: unknown[]
+): Promise<DecodedTxInput | null> {
+    const txInputData =
+        params && params.length > 0 && (params[0] as Record<string, string>).hasOwnProperty('data')
+            ? (params[0] as Record<string, string>).data
+            : null;
+
+    if (!target || !contract || !txInputData) {
+        return null;
+    }
+
+    // TODO: keep a cache to avoid fethcing same ABI multiple times.
+    const identity = new URL(target).host.replace(/.point$/, '');
+    const {_jsonInterface} = await ethereum.loadWebsiteContract(identity, contract);
+
+    if (!addedABIs[`${target}:${contract}`]) {
+        abiDecoder.addABI(_jsonInterface);
+        addedABIs[`${target}:${contract}`] = true;
+    }
+
+    const decoded = abiDecoder.decodeMethod(txInputData);
+    return decoded ? (decoded as DecodedTxInput) : null;
+}


### PR DESCRIPTION
If the RPC request to `sendTransaction` includes information about which Smart Contract it wants to call, Point Engine will fetch the ABI, decode the transaction input data and added to the response, so that clients can display human-readable information to users.

In order not to introduce any breaking changes, if the contract information is not provided, the response is the same as it was before.

Also to maintain backwards compatibility, the decoded data is added as a new key in the payload.