### PR TITLE
Make sure gasPrice is set as per the config value

### DIFF
--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -932,7 +932,7 @@ ethereum.getOwner = () => getWeb3().utils.toChecksumAddress(getNetworkAddress())
 
 ethereum.getGasPrice = async (network = 'xnet') => {
     if (config.has(`network.web3.${network}.gas_price_wei`)) {
-        return Number(config.has(`network.web3.${network}.gas_price_wei`));
+        return Number(config.get(`network.web3.${network}.gas_price_wei`));
     }
 
     const gasPrice = await getWeb3().eth.getGasPrice();

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -962,6 +962,11 @@ ethereum.toHex = n => getWeb3().utils.toHex(n);
 
 ethereum.send = ({method, params = [], id, network}) =>
     new Promise((resolve, reject) => {
+        if (params.length > 0 && config.has(`network.web3.${network}.gas_price_wei`)) {
+            const decimal = Number(config.get(`network.web3.${network}.gas_price_wei`));
+            params[0].gasPrice = `0x${decimal.toString(16)}`;
+        }
+
         getWeb3({chain: network}).currentProvider.send(
             {
                 id,


### PR DESCRIPTION
This PR addresses two things:

1. A stupid mistake I made, using `has` instead of `get` to grab a value from config.
2. Explicitly set `gasPrice`  on txs that we process through the RPC handler.

I liked a post, wrote a comment and sent an email and the tx fees are very low, as expected.
![Screenshot from 2022-08-05 17-53-23](https://user-images.githubusercontent.com/101118664/183163101-d3dfb4b3-53e0-46b4-8628-1c2c4568984e.png)

