### PR TITLE
Pagination of events query

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "start:dev": "NODE_ENV=development npm run watch",
     "start:e2e": "MODE=e2e npm run watch",
     "watch": "nodemon",
-    "build": "tsc",
+    "build": "perl -i -pe\"s|timeout: 20000|timeout: 60000|\" node_modules/@trufflesuite/web3-provider-engine/subproviders/rpc.js && tsc",
     "pkg": "pkg .",
     "pkg:win": "pkg --targets node16-win-x64 --output bin/pointnetwork-win .",
     "pkg:linux": "pkg --targets node16-linux-x64 --output bin/pointnetwork-linux .",

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -339,29 +339,26 @@ ethereum.getPastEvents = async (
 
     const eventBlocksPageSize = 10000;
     let latestBlock = 0;
-    if(options.toBlock === 'latest'){
+    if (options.toBlock === 'latest'){
         latestBlock = await getWeb3().eth.getBlockNumber();
-    }else{
+    } else {
         latestBlock = options.toBlock;
     }
 
-    let ranges = [];
-    for(let start = options.fromBlock; start < latestBlock; start += eventBlocksPageSize){
+    const ranges = [];
+    for (let start = options.fromBlock; start < latestBlock; start += eventBlocksPageSize){
         ranges.push(
             {
                 fromBlock: start, 
                 toBlock: (start + eventBlocksPageSize < latestBlock 
-                                ? start + eventBlocksPageSize 
-                                : latestBlock )
+                    ? start + eventBlocksPageSize 
+                    : latestBlock)
             });
     }
-    console.log('------------------');
-    ranges.map(({fromBlock, toBlock}) => console.log({...options, fromBlock, toBlock, event}));
-    console.log('------------------');
-    let eventsParts = await Promise.all(ranges.map(({fromBlock, toBlock}) => contract.getPastEvents(event, {...options, fromBlock, toBlock})))
+    const eventsParts = await Promise.all(ranges.map(({fromBlock, toBlock}) => contract.getPastEvents(event, {...options, fromBlock, toBlock})));
     let events = [];
-    for (let evPart of eventsParts){
-        events = events.concat(evPart)
+    for (const evPart of eventsParts){
+        events = events.concat(evPart);
     }
     //let events = await contract.getPastEvents(event, options);
 

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -337,7 +337,33 @@ ethereum.getPastEvents = async (
         options.filter.identityOwner = ethereum.toChecksumAddress(options.filter.identityOwner);
     }
 
-    let events = await contract.getPastEvents(event, options);
+    const eventBlocksPageSize = 10000;
+    let latestBlock = 0;
+    if(options.toBlock === 'latest'){
+        latestBlock = await getWeb3().eth.getBlockNumber();
+    }else{
+        latestBlock = options.toBlock;
+    }
+
+    let ranges = [];
+    for(let start = options.fromBlock; start < latestBlock; start += eventBlocksPageSize){
+        ranges.push(
+            {
+                fromBlock: start, 
+                toBlock: (start + eventBlocksPageSize < latestBlock 
+                                ? start + eventBlocksPageSize 
+                                : latestBlock )
+            });
+    }
+    console.log('------------------');
+    ranges.map(({fromBlock, toBlock}) => console.log({...options, fromBlock, toBlock, event}));
+    console.log('------------------');
+    let eventsParts = await Promise.all(ranges.map(({fromBlock, toBlock}) => contract.getPastEvents(event, {...options, fromBlock, toBlock})))
+    let events = [];
+    for (let evPart of eventsParts){
+        events = events.concat(evPart)
+    }
+    //let events = await contract.getPastEvents(event, options);
 
     //filter non-indexed properties from return value for convenience
     if (options.hasOwnProperty('filter') && Object.keys(options.filter).length > 0) {


### PR DESCRIPTION
Increase speed of querying for events due small parallel request to try to solve PZ-412. However, it seems that the query for events is becoming much slower when the number of blocks increase. This solution make the interface works, but takes a long time to load. 