### PR TITLE
PN-211 Add an identity cache to avoid overcalling SNS/ENS

### DIFF
--- a/src/name_service/identity-cache.test.ts
+++ b/src/name_service/identity-cache.test.ts
@@ -1,0 +1,141 @@
+import {IdentityCache} from './identity-cache';
+import {IdentityData} from './types';
+
+let cache: IdentityCache;
+beforeEach(() => (cache = new IdentityCache(200)));
+
+const sleep = (timeout: number) => new Promise(resolve => setTimeout(resolve, timeout));
+
+describe('IdentityCache', () => {
+    const identityA: IdentityData = {
+        identity: 'A',
+        address: 'blockchain-address-of-identity-a',
+        publicKey: 'publick-key-of-identity-a',
+        network: 'point'
+    };
+
+    const identityB: IdentityData = {
+        identity: 'B',
+        address: 'blockchain-address-of-identity-b',
+        publicKey: 'publick-key-of-identity-b',
+        network: 'ethereum'
+    };
+
+    const identityC: IdentityData = {
+        identity: 'C',
+        address: 'blockchain-address-of-identity-c',
+        publicKey: 'publick-key-of-identity-c',
+        network: 'solana'
+    };
+
+    it('should add two entries', () => {
+        expect.assertions(1);
+        cache.add(identityA.address, identityA);
+        cache.add(identityB.address, identityB);
+        expect(cache.size()).toEqual(2);
+    });
+
+    it('should overwrite older entry with same key and not add duplicates', () => {
+        expect.assertions(2);
+        const k = identityA.address;
+        cache.add(k, identityB);
+        cache.add(k, identityA);
+        expect(cache.size()).toEqual(1);
+        expect(cache.get(k)?.identity).toEqual(identityA.identity);
+    });
+
+    it('should return the correct entry when it is present and not expired', () => {
+        expect.assertions(4);
+        const k = identityC.address;
+        cache.add(k, identityC);
+        expect(cache.get(k)?.identity).toEqual(identityC.identity);
+        expect(cache.get(k)?.address).toEqual(identityC.address);
+        expect(cache.get(k)?.publicKey).toEqual(identityC.publicKey);
+        expect(cache.get(k)?.network).toEqual(identityC.network);
+    });
+
+    it('should return correct entry after a period of time but before expiration', async () => {
+        expect.assertions(1);
+        const k = identityC.address;
+        cache.add(k, identityC);
+        await sleep(100);
+        expect(cache.get(k)?.identity).toEqual(identityC.identity);
+    });
+
+    it('should return null when entry is not present', () => {
+        expect.assertions(1);
+        expect(cache.get(identityC.address)).toBeNull();
+    });
+
+    it('should return null when entry is expired', async () => {
+        expect.assertions(3);
+        const k = identityC.address;
+        cache.add(k, identityC);
+        expect(cache.size()).toEqual(1);
+        await sleep(250);
+        expect(cache.get(k)).toBeNull();
+        expect(cache.size()).toEqual(0);
+    });
+
+    it('should return true when an entry is present and not expired', () => {
+        expect.assertions(1);
+        const k = identityA.address;
+        cache.add(k, identityA);
+        expect(cache.has(k)).toEqual(true);
+    });
+
+    it('should return true after a period of time but before expiration', async () => {
+        expect.assertions(1);
+        const k = identityA.address;
+        cache.add(k, identityA);
+        await sleep(100);
+        expect(cache.has(k)).toBe(true);
+    });
+
+    it('should return false when an entry is not present', () => {
+        expect.assertions(1);
+        expect(cache.has(identityA.address)).toBe(false);
+    });
+
+    it('should return false when an entry is expired', async () => {
+        expect.assertions(2);
+        const k = identityA.address;
+        cache.add(k, identityA);
+        await sleep(250);
+        expect(cache.has(k)).toBe(false);
+        expect(cache.size()).toEqual(0);
+    });
+
+    it('should remove all expired entries', async () => {
+        expect.assertions(4);
+        cache.add(identityA.address, identityA);
+        cache.add(identityB.address, identityB);
+        await sleep(100);
+        cache.add(identityC.address, identityC);
+        await sleep(150);
+        cache.clear();
+        expect(cache.size()).toEqual(1);
+        expect(cache.has(identityA.address)).toBe(false);
+        expect(cache.has(identityB.address)).toBe(false);
+        expect(cache.has(identityC.address)).toBe(true);
+    });
+
+    it('should remove all entries', async () => {
+        expect.assertions(1);
+        cache.add(identityA.address, identityA);
+        cache.add(identityB.address, identityB);
+        await sleep(250);
+        cache.add(identityC.address, identityC);
+        cache.drop();
+        expect(cache.size()).toEqual(0);
+    });
+
+    it('should serialize cache to JSON string', () => {
+        expect.assertions(1);
+        const k = identityA.address;
+        cache.add(k, identityA);
+        const str = cache.toJSON();
+        const obj = JSON.parse(str);
+        expect(obj[k].entry.identity).toEqual(identityA.identity);
+    });
+});

--- a/src/name_service/identity-cache.ts
+++ b/src/name_service/identity-cache.ts
@@ -1,0 +1,79 @@
+import {IdentityData} from './types';
+
+export class IdentityCache {
+    private identities = new Map<string, {exp: number; entry: IdentityData}>();
+    private ttlMs: number;
+
+    constructor(ttlMs?: number) {
+        this.ttlMs = ttlMs ?? 5 * 60 * 1000; // default: 5 minutes.
+    }
+
+    private checkExpired(k: string) {
+        const id = this.identities.get(k);
+        if (id?.exp && Date.now() > id.exp) {
+            this.identities.delete(k);
+        }
+    }
+
+    /**
+     * Add entry to the cache.
+     */
+    public add(k: string, v: IdentityData) {
+        this.identities.set(k, {
+            exp: Date.now() + this.ttlMs,
+            entry: v
+        });
+    }
+
+    /**
+     * Retrieve entry from the cache.
+     * (returns `null` if not found)
+     */
+    public get(k: string): IdentityData | null {
+        this.checkExpired(k);
+        const item = this.identities.get(k);
+        return item ? item.entry : null;
+    }
+
+    /**
+     * Whether the given key is already in the cache.
+     * (expired entries will be deleted and this method will return `false`)
+     */
+    public has(k: string) {
+        this.checkExpired(k);
+        return this.identities.has(k);
+    }
+
+    /**
+     * Amount of entries.
+     * (may include expired entries as they are removed lazily,
+     * when trying to access them with `has` or `get`)
+     */
+    public size() {
+        return this.identities.size;
+    }
+
+    /**
+     * Remove all expired entries.
+     */
+    public clear() {
+        this.identities.forEach((_, k) => this.checkExpired(k));
+    }
+
+    /**
+     * Remove all entries.
+     * (removes everything, expired and not expired)
+     */
+    public drop() {
+        this.identities.clear();
+    }
+
+    /**
+     * Convert to JSON string.
+     */
+    public toJSON() {
+        return JSON.stringify(Object.fromEntries(this.identities));
+    }
+}
+
+export const identityCache = new IdentityCache();

--- a/src/name_service/types.ts
+++ b/src/name_service/types.ts
@@ -9,3 +9,18 @@ export type DomainRegistry = {
     owner: string;
     content: string | null;
 };
+
+export type IdentityData = {
+    identity: string | null;
+    address: string;
+    publicKey: string;
+    network: 'point' | 'solana' | 'ethereum';
+};
+
+export type IdentityParams = {
+    solAddress?: string;
+    ethAddress?: string;
+    targets?: string[];
+    solNetwork?: string;
+    ethNetwork?: string;
+};

--- a/src/rpc/decode.test.ts
+++ b/src/rpc/decode.test.ts
@@ -7,21 +7,19 @@ const sleep = (timeout: number) => new Promise(resolve => setTimeout(resolve, ti
 
 describe('Decode Tx Input Data', () => {
     it('should add two entries', () => {
+        expect.assertions(3);
         abiTracker.add('social', 'PointSocial');
         abiTracker.add('email', 'PointEmail');
-
-        expect.assertions(3);
         expect(abiTracker.has('social', 'PointSocial')).toBe(true);
         expect(abiTracker.has('email', 'PointEmail')).toBe(true);
         expect(abiTracker.len()).toEqual(2);
     });
 
     it('should not add duplicate entries', () => {
-        abiTracker.add('social', 'PointSocial');
-        abiTracker.add('social', 'PointSocial');
-        abiTracker.add('social', 'PointSocial');
-
         expect.assertions(1);
+        abiTracker.add('social', 'PointSocial');
+        abiTracker.add('social', 'PointSocial');
+        abiTracker.add('social', 'PointSocial');
         expect(abiTracker.len()).toEqual(1);
     });
 
@@ -31,9 +29,8 @@ describe('Decode Tx Input Data', () => {
     });
 
     it('should delete an expired entry', async () => {
-        abiTracker.add('social', 'PointSocial');
-
         expect.assertions(3);
+        abiTracker.add('social', 'PointSocial');
         expect(abiTracker.has('social', 'PointSocial')).toBe(true);
         await sleep(1_000);
         expect(abiTracker.has('social', 'PointSocial')).toBe(false);
@@ -41,12 +38,11 @@ describe('Decode Tx Input Data', () => {
     });
 
     it('should overwrite older entry', async () => {
-        abiTracker.add('social', 'PointSocial');
-        await sleep(300);
-        abiTracker.add('social', 'PointSocial');
-        await sleep(300);
-
         expect.assertions(2);
+        abiTracker.add('social', 'PointSocial');
+        await sleep(300);
+        abiTracker.add('social', 'PointSocial');
+        await sleep(300);
         expect(abiTracker.has('social', 'PointSocial')).toBe(true);
         expect(abiTracker.len()).toEqual(1);
     });


### PR DESCRIPTION
We call SNS/ENS to check if ethereum and solana accounts have domains associated to them. We do this when getting identities and wallet information, which can result in large delays for users, and an overuse of services such as Infura.

This PR can be merged as is, but as an additional improvement, I have opened PR #564 against this branch. Please check it out and let me know your thoughts.