### PR TITLE
Serge improvements aug 7

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -50,6 +50,7 @@ storage:
   arweave_host: arweave.net
   arweave_protocol: https
   arweave_port: 443
+  use_arlocal: false
 zproxy:
   port: 8666
   # 2 ports below are not used to receive requests and should not be exposed

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import path from 'path';
-import {promises as fs, existsSync} from 'fs';
+import {promises as fs, existsSync, lstatSync} from 'fs';
 import {parse} from 'query-string';
 import axios from 'axios';
-import {makeSurePathExists, readFileByPath} from '../../../util';
+import {readFileByPath} from '../../../util';
 import {FastifyInstance, FastifyReply, FastifyRequest} from 'fastify';
 import ZProxySocketController from '../../../api/sockets/ZProxySocketController';
 import {SocketStream} from 'fastify-websocket';
@@ -115,8 +115,8 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
                 rootDir = deployConfig.rootDir;
             }
 
-            const publicPath = path.resolve(zappDir, rootDir); if (!FS.existsSync(publicPath)) throw new Error('Public path ' + publicPath + ' doesnt exist.');
-            const routesJsonPath = path.resolve(zappDir, 'routes.json'); if (!FS.existsSync(routesJsonPath)) throw new Error('Routes file ' + routesJsonPath + ' doesnt exist.');
+            const publicPath = path.resolve(zappDir, rootDir); if (!existsSync(publicPath)) throw new Error('Public path ' + publicPath + ' doesnt exist.');
+            const routesJsonPath = path.resolve(zappDir, 'routes.json'); if (!existsSync(routesJsonPath)) throw new Error('Routes file ' + routesJsonPath + ' doesnt exist.');
             const routes = JSON.parse(await fs.readFile(routesJsonPath, 'utf8'));
 
             const {routeParams, templateFilename, rewritedPath} = getParamsAndTemplate(
@@ -150,10 +150,10 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
             } else {
                 // This is a static asset
                 const filePath = path.join(publicPath, urlPath);
-                if (! FS.existsSync(filePath)) {
+                if (! existsSync(filePath)) {
                     return res.status(404).send('Not Found');
                 }
-                if (! FS.lstatSync(filePath).isFile()) {
+                if (! lstatSync(filePath).isFile()) {
                     return res.status(403).send('Directory listing not allowed');
                 }
 
@@ -241,7 +241,7 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
                             ...((req.body as Record<string, unknown>) ?? {})
                         });
                     } else {
-                        // NOTE: silently move on since Object.keys(routes).length !==1 
+                        // NOTE: silently move on since Object.keys(routes).length !==1
                     }
                 }
                 if (!renderedId) {
@@ -372,7 +372,7 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
                                 ...((req.body as Record<string, unknown>) ?? {})
                             });
                     } else {
-                        // NOTE: silently move on since Object.keys(routes).length !==1 
+                        // NOTE: silently move on since Object.keys(routes).length !==1
                     }
                 }
 

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -96,9 +96,9 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
 
             const zappName = host.endsWith('dev') ? `${host.split('dev')[0]}.point` : host;
 
-            const zappsDir = String(config.get('zappsdir'));
+            const zappsDir: string = config.get('zappsdir');
             let zappDir: string;
-            if (zappsDir !== 'undefined' && zappsDir !== '' && zappsDir !== 'null') {
+            if (zappsDir) {
                 if (zappsDir.startsWith('/') || zappsDir.startsWith('~')) {
                     zappDir = path.resolve(zappsDir, zappName);
                 } else {
@@ -115,8 +115,16 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
                 rootDir = deployConfig.rootDir;
             }
 
-            const publicPath = path.resolve(zappDir, rootDir); if (!existsSync(publicPath)) throw new Error('Public path ' + publicPath + ' doesnt exist.');
-            const routesJsonPath = path.resolve(zappDir, 'routes.json'); if (!existsSync(routesJsonPath)) throw new Error('Routes file ' + routesJsonPath + ' doesnt exist.');
+            const publicPath = path.resolve(zappDir, rootDir);
+            if (!existsSync(publicPath)) {
+                throw new Error('Public path ' + publicPath + ' doesnt exist.');
+            }
+
+            const routesJsonPath = path.resolve(zappDir, 'routes.json');
+            if (!existsSync(routesJsonPath)) {
+                throw new Error('Routes file ' + routesJsonPath + ' doesnt exist.');
+            }
+
             const routes = JSON.parse(await fs.readFile(routesJsonPath, 'utf8'));
 
             const {routeParams, templateFilename, rewritedPath} = getParamsAndTemplate(

--- a/src/client/proxy/handlers/mirror.ts
+++ b/src/client/proxy/handlers/mirror.ts
@@ -30,7 +30,24 @@ async function getWeb2MirrorContent() {
 
 export async function getMirrorWeb2Page(req: FastifyRequest) {
     const urlData = req.urlData();
+    const host = String(urlData.host);
     const queryParams = parse(urlData.query ?? '');
+
+    // Some hardcoded domains
+    const FULL_DOMAIN_REDIRECTS : Record<string, string> = {
+        'fonts.googleapis.com': 'gfonts.mirror.point',
+        'fonts.gstatic.com': 'gfontfiles.mirror.point'
+    };
+    if (host.toLowerCase() in FULL_DOMAIN_REDIRECTS) {
+        const redirectedHost = FULL_DOMAIN_REDIRECTS[ host.toLowerCase() ];
+        let url = req.raw.url ?? '';
+        if (host === 'fonts.googleapis.com') {
+            url = url.replace('/css', '/css.css');
+            url = url.replace('/css2', '/css2.css');
+        }
+        return 'https://' + redirectedHost + (!url.startsWith('/') ? '/' : '') + url;
+    }
+
     if (queryParams.mirror === 'false') {
         return;
     }

--- a/src/client/proxy/middleware/cors.ts
+++ b/src/client/proxy/middleware/cors.ts
@@ -4,10 +4,10 @@ import {preHandlerHookHandler} from 'fastify';
  * Allows Cross-Origin Requests to `https://mirror.point`.
  */
 export const cors: preHandlerHookHandler = (req, res, done) => {
-    const protocol = req.protocol;
     const {host} = req.urlData();
 
-    if (`${protocol}://${host}` === 'https://mirror.point') {
+    // Note: include original web2 urls too, not just web3 redirects, because otherwise the redirect won't even work, CORS check will kill it
+    if (['mirror.point', 'gfontfiles.mirror.point', 'gfonts.mirror.point'].includes(String(host).toLowerCase())) {
         // Requests that are a result of a redirection during a CORS request
         // have the `Origin` header set to `null`.
         // Hence, we allow all origins (*) for `https://mirror.point`.

--- a/src/client/proxy/proxyUtils.ts
+++ b/src/client/proxy/proxyUtils.ts
@@ -44,16 +44,16 @@ export const isDirectoryJson = (text: string) => {
 };
 
 export const setAsAttachment = (
-    urlPathname: string, 
-    contentType: string, 
+    urlPathname: string,
+    contentType: string,
     acceptHeaders: string) => {
     const isAttachment = urlPathname.startsWith('/_storage/') && // request directly from storage
     !contentType.startsWith('image') && // not an image
     !contentType.startsWith('video') && // not a video
     (
-        acceptHeaders.includes('text/html') || 
-        acceptHeaders.includes('application/xhtml+xml') || 
-        acceptHeaders.includes('application/xml') || 
+        acceptHeaders.includes('text/html') ||
+        acceptHeaders.includes('application/xhtml+xml') ||
+        acceptHeaders.includes('application/xml') ||
         acceptHeaders.includes('*/*')
     );
     return isAttachment;

--- a/src/client/storage/config.ts
+++ b/src/client/storage/config.ts
@@ -9,6 +9,7 @@ export const UPLOAD_LOOP_INTERVAL = Number(config.get('storage.upload_loop_inter
 export const UPLOAD_RETRY_LIMIT = Number(config.get('storage.upload_retry_limit'));
 export const CHUNK_SIZE = Number(config.get('storage.chunk_size_bytes'));
 export const GATEWAY_URL: string = config.get('storage.arweave_gateway_url');
+export const USE_ARLOCAL = Boolean(config.get('storage.use_arlocal'));
 export const MODE: string = config.get('mode');
 export const HOST: string = config.get('storage.arweave_host');
 export const PORT = Number(config.get('storage.arweave_port'));

--- a/src/client/storage/init/init.zappdev.ts
+++ b/src/client/storage/init/init.zappdev.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
-import {HOST, PORT, PROTOCOL} from '../config';
+import {HOST, PORT, PROTOCOL, USE_ARLOCAL} from '../config';
 import arweave, {arweaveKey} from '../client/client_zappdev';
 
 const init = async () => {
     // mint tokens on arlocal
-    if (arweaveKey !== undefined) {
+    if (USE_ARLOCAL && arweaveKey !== undefined) {
         const address = await arweave.wallets.jwkToAddress(arweaveKey);
         await axios.get(`${PROTOCOL}://${HOST}:${PORT}/mint/${address}/100000000000000000000`);
     }


### PR DESCRIPTION
This is an update from Aug 7, so needs to be merged properly
- a few bugfixes to renderer (a bunch of returns and awaits were missing, so zhtml error messages weren't properly propagating to the browser), AR mint not reading the environment mode properly
- add throw tag into zhtml {% throw 'anything' %} will throw 'anything' as an error, instead of using a bunch of multi-nested ifs in zhtml logic
- two new web2 domain redirects with CORS enabled: fonts.googleapis.com -> gfonts.mirror.point, fonts.gstatic.com -> gfontfiles.mirror.point

While it's being merged, I'll try to upload the mirrors content and we can test whether we now have fully web3 copy of Google Fonts perfectly working

Upd: +if there is a .local domain, it tries to resolve it using zappsdir even in production mode. That was a quick hack for me while the dev env was (still is?) broken. Lmk your thoughts on whether any issues might arise out of it. Maybe we should disable it