### PR TITLE
Send empty `alias` when SNS/ENS times out

### DIFF
--- a/src/api/controllers/WalletController.js
+++ b/src/api/controllers/WalletController.js
@@ -115,7 +115,7 @@ class WalletController extends PointSDKController {
                                         alias = '';
                                 }
                             } catch (e) {
-                                alias = 'Error';
+                                alias = '';
                             }
                         })()
                     ]);


### PR DESCRIPTION
Timeouts have been adding to the requests to resolve SNS/ENS domains. When an error occurs, we send the string `Error` as the alias, which causes the UI to render `Error` as the wallet address.

I think a better approach is to send an empty string. The UI is prepared to handle this, it will fallback to rendering the blockchain address.

![Screenshot from 2022-08-11 10-24-13](https://user-images.githubusercontent.com/101118664/184144692-45218c10-c055-4fc9-bc48-1f2ca54803ea.png)

