### PR TITLE
Remove background job to fetch events

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,15 +1,9 @@
 import startApiServer from '../api';
 import startProxy from '../client/proxy';
 import initStorage from '../client/storage/init';
-import startBackgroundJobs from '../background/start_background_jobs';
 
 const startPoint = async () => {
-    await Promise.all([
-        startApiServer(),
-        startProxy(),
-        initStorage(),
-        startBackgroundJobs()
-    ]);
+    await Promise.all([startApiServer(), startProxy(), initStorage()]);
 };
 
 export default startPoint;


### PR DESCRIPTION
Switching off background job to fetch events since we have stopped using them in Point Explorer.