### PR TITLE
Fix the Point Browser not opening web2 links

### DIFF
--- a/internal/explorer.point/package.json
+++ b/internal/explorer.point/package.json
@@ -28,7 +28,7 @@
     "wouter": "^2.7.4"
   },
   "scripts": {
-    "clear": "mkdir -p \"./public\" && rm -rf \"./public/*\" \".cache\" \".parcel-cache\"",
+    "clear": "rm -rf \"./public/*\" \".cache\" \".parcel-cache\"",
     "start": "react-scripts start",
     "watch:docker": "./watch.docker.js",
     "prebuild": "npm ci",

--- a/internal/explorer.point/package.json
+++ b/internal/explorer.point/package.json
@@ -28,7 +28,7 @@
     "wouter": "^2.7.4"
   },
   "scripts": {
-    "clear": "rm -rf \"./public/*\" \".cache\" \".parcel-cache\"",
+    "clear": "rm -rf ./public \".cache\" \".parcel-cache\" && mkdir public",
     "start": "react-scripts start",
     "watch:docker": "./watch.docker.js",
     "prebuild": "npm ci",

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
+        "cross-env": "^7.0.3",
         "eslint": "^8.9.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
@@ -7818,6 +7819,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -29584,6 +29603,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-fetch": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "umzug": "^3.0.0",
     "web3": "^1.7.3",
     "web3-provider-engine": "16.0.3",
-    "web3-providers-http": "1.6.0",
-    "point-contract-manager": "github:pointnetwork/point-contracts#v0.1.0"
+    "web3-providers-http": "1.6.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",
@@ -96,6 +95,7 @@
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.9.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-prefer-arrow": "^1.2.3",
@@ -118,11 +118,11 @@
   "scripts": {
     "test": "MODE=test jest --forceExit",
     "test:ci": "cp ./resources/blockchain-test-key.json ./tests/resources/key.json && POINT_KEYSTORE=./tests/resources MODE=test jest --forceExit --reporters=default --reporters=jest-junit",
-    "test:docker": "MODE=test TESTING_IN_DOCKER=true jest tests/docker/*.spec.js --forceExit --modulePathIgnorePatterns [] --reporters=default --reporters=jest-junit",
+    "test:docker": "cross-env MODE=test TESTING_IN_DOCKER=true jest tests/docker/*.spec.js --forceExit --modulePathIgnorePatterns [] --reporters=default --reporters=jest-junit",
     "start": "node dist/index.js",
-    "start:zappdev": "MODE=zappdev npm run watch",
-    "start:dev": "NODE_ENV=development npm run watch",
-    "start:e2e": "MODE=e2e npm run watch",
+    "start:zappdev": "cross-env MODE=zappdev npm run watch",
+    "start:dev": "cross-env NODE_ENV=development npm run watch",
+    "start:e2e": "cross-env MODE=e2e npm run watch",
     "watch": "npm run --prefix ./internal/explorer.point --ignore-scripts build && nodemon",
     "build": "perl -i -pe\"s|timeout: 20000|timeout: 60000|\" node_modules/@trufflesuite/web3-provider-engine/subproviders/rpc.js && tsc",
     "patch": "perl -i -pe\"s|timeout: 20000|timeout: 60000|\" node_modules/@trufflesuite/web3-provider-engine/subproviders/rpc.js",

--- a/src/api/controllers/Web2Controller.js
+++ b/src/api/controllers/Web2Controller.js
@@ -11,7 +11,7 @@ class Web2Controller extends PointSDKController {
     }
 
     async open() {
-        if (this.host !== 'point') return this.reply.callNotFound();
+        // if (this.host !== 'point') return this.reply.callNotFound();
         const url = this.payload.urlToOpen;
         try {
             open(url);

--- a/tests/api/web2Controller.spec.js
+++ b/tests/api/web2Controller.spec.js
@@ -5,22 +5,6 @@ const open = require('open');
 jest.mock('open', () => jest.fn(async () => {}));
 
 describe('Web2 controller', () => {
-    it('Should return 404 if host is not point', async () => {
-        expect.assertions(1);
-
-        const res = await apiServer.inject({
-            method: 'POST',
-            url: 'https://open.point/v1/api/web2/open',
-            body: JSON.stringify({urlToOpen: 'https://example1.com'}),
-            headers: {
-                'host': 'open.point',
-                'Content-Type': 'application/json'
-            }
-        });
-
-        expect(res.statusCode).toEqual(404);
-    });
-
     it('Should open web2 link', async () => {
         expect.assertions(3);
 
@@ -29,17 +13,19 @@ describe('Web2 controller', () => {
             url: 'https://point/v1/api/web2/open',
             body: JSON.stringify({urlToOpen: 'https://example2.com'}),
             headers: {
-                'host': 'point',
+                host: 'example2.com',
                 'Content-Type': 'application/json'
             }
         });
 
         expect(res.statusCode).toEqual(200);
         expect(open).toHaveBeenCalledWith('https://example2.com');
-        expect(res.payload).toEqual(JSON.stringify({
-            status: 200,
-            data: true,
-            headers: {}
-        }));
+        expect(res.payload).toEqual(
+            JSON.stringify({
+                status: 200,
+                data: true,
+                headers: {}
+            })
+        );
     });
 });


### PR DESCRIPTION
- Fixed the web2 links not opening by commenting out a line of code (didn't knew if it might be useful later on so commented it)
- Removed redundant `point-contract-manager` package from the root `package.json` 
- Installed `cross-env` for cross platform compatibility in the root `package.json` and updated & tested `scripts`
- Fixed the `clear` script in `internal/explorer.point/package.json`. The earlier script would create a `-p` directory and fail to delete the `public` directory. Now it works fine - tested on Windows using git-bash. Please test on other systems as well.