### PR TITLE
Simplify deploy command by removing the API call

### DIFF
--- a/src/client/zweb/deployer_old/index.js
+++ b/src/client/zweb/deployer_old/index.js
@@ -569,6 +569,10 @@ class Deployer {
             } else {
                 if (process.env.MODE === 'zappdev') {
                     await this.registerNewIdentity(identity, owner);
+                } else {
+                    throw new Error(
+                        `You must register ${identity} before you can make a deployment. Start Point, head over to https://point in Point Browser, register ${identity} and then retry the deploy command.`
+                    );
                 }
             }
         } else {

--- a/tests/api/walletController.spec.js
+++ b/tests/api/walletController.spec.js
@@ -1,11 +1,16 @@
+import config from 'config';
 import apiServer from '../../src/api/server';
 import ethereum from '../../src/network/providers/ethereum';
 import solana from '../../src/network/providers/solana';
 import httpsServer from '../../src/client/proxy/httpsServer';
 
-jest.mock('../../src/network/providers/ethereum', () => ({getBalance: jest.fn(async () => 1000000000000)}));
+jest.mock('../../src/network/providers/ethereum', () => ({
+    getBalance: jest.fn(async () => 1000000000000)
+}));
 
-jest.mock('../../src/network/providers/solana', () => ({getBalance: jest.fn(async () => 1000000000)}));
+jest.mock('../../src/network/providers/solana', () => ({
+    getBalance: jest.fn(async () => 1000000000)
+}));
 
 describe('Wallet controller', () => {
     it('Public key', async () => {
@@ -71,7 +76,7 @@ describe('Wallet controller', () => {
         expect(res.statusCode).toEqual(200);
         expect(ethereum.getBalance).toHaveBeenCalledWith({
             address: expect.stringMatching(/^0x/),
-            network: 'xnet'
+            network: config.get('network.default_network')
         });
         expect(JSON.parse(res.payload)).toEqual({
             status: 200,

--- a/tests/api/walletController.spec.js
+++ b/tests/api/walletController.spec.js
@@ -4,13 +4,9 @@ import ethereum from '../../src/network/providers/ethereum';
 import solana from '../../src/network/providers/solana';
 import httpsServer from '../../src/client/proxy/httpsServer';
 
-jest.mock('../../src/network/providers/ethereum', () => ({
-    getBalance: jest.fn(async () => 1000000000000)
-}));
+jest.mock('../../src/network/providers/ethereum', () => ({getBalance: jest.fn(async () => 1000000000000)}));
 
-jest.mock('../../src/network/providers/solana', () => ({
-    getBalance: jest.fn(async () => 1000000000)
-}));
+jest.mock('../../src/network/providers/solana', () => ({getBalance: jest.fn(async () => 1000000000)}));
 
 describe('Wallet controller', () => {
     it('Public key', async () => {


### PR DESCRIPTION
Functionality is the same except when the **target identity** is not registered. In this case we throw early with the following error message: 

"Error: You must register <identity> before you can make a deployment. Start Point, head over to https://point in Point Browser, register <identity> and then retry the deploy command."