### PR TITLE
PN-218 add to identity cache upon registration

### DIFF
--- a/src/api/controllers/IdentityController.js
+++ b/src/api/controllers/IdentityController.js
@@ -13,17 +13,17 @@ const {default: csrfTokens} = require('../../client/zweb/renderer/csrfTokens');
 const {getIdentity} = require('../../name_service/identity');
 const config = require('config');
 const Web3 = require('web3');
+const {addToCache} = require('../../name_service/identity-cache');
 
 const EMPTY_REFERRAL_CODE = '000000000000';
 
 const IKV_PUT_INTERFACE = {
-    inputs:
-        [
-            {internalType:'string', name:'identity', type:'string'},
-            {internalType:'string', name:'key', type:'string'},
-            {internalType:'string', name:'value', type:'string'},
-            {internalType:'string', name:'version', type:'string'}
-        ],
+    inputs: [
+        {internalType: 'string', name: 'identity', type: 'string'},
+        {internalType: 'string', name: 'key', type: 'string'},
+        {internalType: 'string', name: 'value', type: 'string'},
+        {internalType: 'string', name: 'version', type: 'string'}
+    ],
     name: 'ikvPut',
     outputs: [],
     stateMutability: 'nonpayable',
@@ -267,6 +267,9 @@ class IdentityController extends PointSDKController {
                 );
             }
 
+            // Add to cache so that users don't have to wait until expiration to see the updates.
+            addToCache({address: owner, identity, publicKey, network: 'point'});
+
             log.info(
                 {identity, owner, publicKey: publicKey.toString('hex')},
                 'Successfully registered new identity'
@@ -426,26 +429,25 @@ class IdentityController extends PointSDKController {
     }
 
     async ikvPut() {
-        const {
-            identity,
-            key,
-            value,
-            version = 'latest'
-        } = this.req.body;
+        const {identity, key, value, version = 'latest'} = this.req.body;
 
         try {
             const web3 = new Web3();
-            const data = web3.eth.abi.encodeFunctionCall(
-                IKV_PUT_INTERFACE,
-                [identity, key, value, version]
-            );
+            const data = web3.eth.abi.encodeFunctionCall(IKV_PUT_INTERFACE, [
+                identity,
+                key,
+                value,
+                version
+            ]);
             await ethereum.send({
                 method: 'eth_sendTransaction',
-                params:[{
-                    from: getNetworkAddress(),
-                    to: config.get('network.identity_contract_address'),
-                    data
-                }],
+                params: [
+                    {
+                        from: getNetworkAddress(),
+                        to: config.get('network.identity_contract_address'),
+                        data
+                    }
+                ],
                 id: new Date().getTime(),
                 network: 'xnet'
             });

--- a/src/name_service/identity-cache.test.ts
+++ b/src/name_service/identity-cache.test.ts
@@ -1,0 +1,28 @@
+import {identityCache, addToCache} from './identity-cache';
+import {IdentityData} from './types';
+
+describe('addToCache', () => {
+    const network = 'point';
+    const address = '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B';
+    const publicKey =
+        '0xc264f479169ffec607a050dbeb6c894c0cfff4de632358d8e1850d99a290f785d129f4a5a71e8d4f767a753e8dccaaf17636755a6becd69c97baff8e978efb03';
+
+    it('should overwrite identity not yet expired', () => {
+        expect.assertions(4);
+        const key = `point:${address}`;
+
+        const unregistered: IdentityData = {
+            identity: null,
+            address,
+            publicKey,
+            network
+        };
+        identityCache.add(key, unregistered);
+        expect(identityCache.size()).toEqual(1);
+        expect(identityCache.get(key)?.identity).toBeNull();
+
+        addToCache({address, identity: 'my_new_handle', publicKey, network});
+        expect(identityCache.size()).toEqual(1);
+        expect(identityCache.get(key)?.identity).toEqual('my_new_handle');
+    });
+});

--- a/src/name_service/identity-cache.ts
+++ b/src/name_service/identity-cache.ts
@@ -4,3 +4,22 @@ import {CacheFactory} from '../util';
 const expiration = 5 * 60 * 1_000;
 
 export const identityCache = new CacheFactory<string, IdentityData>(expiration);
+
+/**
+ * Utility function to create an identity record and add it to the cache.
+ */
+export function addToCache({
+    address,
+    identity,
+    publicKey,
+    network
+}: {
+    address: string;
+    identity: string;
+    publicKey: string;
+    network: 'point' | 'solana' | 'ethereum';
+}) {
+    const cacheKey = `point:${address}`;
+    const identityRecord: IdentityData = {identity, address, publicKey, network};
+    identityCache.add(cacheKey, identityRecord);
+}

--- a/tests/api/walletController.spec.js
+++ b/tests/api/walletController.spec.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import apiServer from '../../src/api/server';
 import ethereum from '../../src/network/providers/ethereum';
 import solana from '../../src/network/providers/solana';
@@ -71,7 +72,7 @@ describe('Wallet controller', () => {
         expect(res.statusCode).toEqual(200);
         expect(ethereum.getBalance).toHaveBeenCalledWith({
             address: expect.stringMatching(/^0x/),
-            network: 'xnet'
+            network: config.get('network.default_network')
         });
         expect(JSON.parse(res.payload)).toEqual({
             status: 200,


### PR DESCRIPTION
When a new identity is registered, we don't want to wait until the previous cache entry expires, as this results in the user having to wait until expiration to be able to use Point Explorer as intended.

To fix it, as soon as a new identity is registered, we overwrite the previous entry in the cache.