### PR TITLE
Return correct contentType for subidentities

### DIFF
--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -278,7 +278,8 @@ const tryFulfillZhtmlRequest = async (
         renderer = new Renderer({rootDirId: cfg.remoteRootDirId} as any);
     }
 
-    const contentType = ext ? getContentTypeFromExt(ext) : 'text/html';
+    const contentTypeFromExt = getContentTypeFromExt(ext || '');
+    const contentType = contentTypeFromExt || 'text/html';
     res.header('Content-Type', contentType);
 
     // TODO: sanitize


### PR DESCRIPTION
With this, the TLD part of a subidentity will not be treated as an unknown file extension and the proxy will render `text/html`.