### PR TITLE
Reduce upload loop interval

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -33,7 +33,7 @@ storage:
   download_cache_path: client_storage_download_cache
   concurrent_upload_limit: 10
   concurrent_validation_limit: 10
-  upload_loop_interval: 2000
+  upload_loop_interval: 100
   request_timeout: 30000
   mirror_cache_expiration: 300000
   upload_expire: 60000


### PR DESCRIPTION
As requested, this reduces the upload loop interval to speed up the deployment process.

In my tests, I see:

* upload_loop_interval: 2000 ->  57631 ms
* upload_loop_interval: 100   ->  34557 ms