### PR TITLE
PN-217 Use `POINT` record of Solana Domain Registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,9 +1834,9 @@
       }
     },
     "node_modules/@bonfida/spl-name-service": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.44.tgz",
-      "integrity": "sha512-XYE6wOkQUMdA2Dz0b+HkOLlfviK2FQTLuALe3A8Ux12AMLxZIu9UTuo/WLGw4nh/SpJh08/S9Oie715055Mung==",
+      "version": "0.1.50",
+      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.50.tgz",
+      "integrity": "sha512-StwKh4DPuLm/zSpf2Dk6pFr7gYrV7T+XTSafgoGI+2STXrzipPDtUtwXeF56HGKZ/IkUtZh4SRUd42q6U/MyrA==",
       "dependencies": {
         "@bonfida/name-offers": "^0.0.1",
         "@ethersproject/sha2": "^5.5.0"
@@ -25095,9 +25095,9 @@
       }
     },
     "@bonfida/spl-name-service": {
-      "version": "0.1.44",
-      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.44.tgz",
-      "integrity": "sha512-XYE6wOkQUMdA2Dz0b+HkOLlfviK2FQTLuALe3A8Ux12AMLxZIu9UTuo/WLGw4nh/SpJh08/S9Oie715055Mung==",
+      "version": "0.1.50",
+      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.50.tgz",
+      "integrity": "sha512-StwKh4DPuLm/zSpf2Dk6pFr7gYrV7T+XTSafgoGI+2STXrzipPDtUtwXeF56HGKZ/IkUtZh4SRUd42q6U/MyrA==",
       "requires": {
         "@bonfida/name-offers": "^0.0.1",
         "@ethersproject/sha2": "^5.5.0"

--- a/src/api/api_routes.js
+++ b/src/api/api_routes.js
@@ -32,8 +32,18 @@ module.exports = [
     ['POST', '/v1/api/identity/blockTimestamp', 'IdentityController@blockTimestamp'], // TODO: why POST?
     ['POST', '/v1/api/identity/open', 'IdentityController@openLink', {protected: true}],
     ['POST', '/v1/api/identity/register', 'IdentityController@registerIdentity', {protected: true}],
-    ['POST', '/v1/api/identity/sub/register', 'IdentityController@registerSubIdentity', {protected: true}],
-    ['GET', '/v1/api/identity/resolve/:domain', 'IdentityController@resolveDomain', {protected: true}],
+    [
+        'POST',
+        '/v1/api/identity/sub/register',
+        'IdentityController@registerSubIdentity',
+        {protected: true}
+    ],
+    [
+        'GET',
+        '/v1/api/identity/resolve/:domain',
+        'IdentityController@resolveDomain',
+        {protected: false}
+    ],
     ['POST', '/v1/api/identity/ikvPut', 'IdentityController@ikvPut', {protected: true}],
     ['GET', '/v1/api/status/ping', 'PingController@ping'],
     ['GET', '/v1/api/status/meta', 'StatusController@meta'],
@@ -50,10 +60,20 @@ module.exports = [
     ['GET', '/v1/api/wallet/balance', 'WalletController@balance', {protected: true}],
     ['GET', '/v1/api/wallet/address', 'WalletController@address', {protected: true}],
     ['GET', '/v1/api/wallet/getWalletInfo', 'WalletController@getWalletInfo', {protected: true}],
-    ['GET', '/v1/api/wallet/getTokenBalances', 'WalletController@getTokenBalances', {protected: true}],
+    [
+        'GET',
+        '/v1/api/wallet/getTokenBalances',
+        'WalletController@getTokenBalances',
+        {protected: true}
+    ],
     ['POST', '/v1/api/wallet/encryptData', 'WalletController@encryptData', {protected: true}],
     ['POST', '/v1/api/wallet/decryptData', 'WalletController@decryptData', {protected: true}],
-    ['POST', '/v1/api/wallet/decryptSymmetricKey', 'WalletController@decryptSymmetricKey', {protected: true}],
+    [
+        'POST',
+        '/v1/api/wallet/decryptSymmetricKey',
+        'WalletController@decryptSymmetricKey',
+        {protected: true}
+    ],
     [
         'POST',
         '/v1/api/wallet/decryptDataWithDecryptedKey',


### PR DESCRIPTION
There's a new `POINT` record available on Solana Domain Registries, so, instead of writing Point Network data to the main content of the registry, we will use the `POINT` record.

These changes are not backwards compatible in that we don't check for existing data in the main domain content. We could, but I figured nobody was using _.sol_ domains to make deployments yet. So I decided to keep the implementation as simple as possible. But please let me know if you think it's important for us to also support the older implementation.

I had to unprotect the endpoint ` /v1/api/identity/resolve/:domain`, this is called by the Engine, not by Point SDK.