### PR TITLE
Set xnet as a default network for development

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -3,3 +3,6 @@ db:
 log:
   sendLogs: false
   level: debug
+network:
+  default_network: xnet
+  identity_contract_address: "0x8E34Fc67034b8A593E87d5f2644D098A3dBd2Fe7"


### PR DESCRIPTION
Without this change, point explorer is bound to `mainnet`, which is of no use for development.
Of course, it can be overridden by `local-development` config, but IMO it makes sense to use `xnet` by default in development.