### PR TITLE
Hacky config fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ import {Command} from 'commander';
 import disclaimer from './disclaimer';
 import {getContractAddress, compileAndSaveContract} from './util/contract';
 
+if (process.env.NODE_ENV === undefined && process.env.APP_ENV === undefined) {
+    process.env.NODE_ENV = 'production';
+}
+
 export const RUNNING_PKG_MODE = Boolean((process as typeof process & {pkg?: unknown}).pkg);
 
 if (RUNNING_PKG_MODE) {


### PR DESCRIPTION
Without this hack, the default config picked up by the app is `development`. And it always was so, we just didn't mention.
Setting `NODE_ENV=production` doesn't help for packaged app.
So though this fix seems hacky, I think it's the best possible solution.