### PR TITLE
PN-223 sol to point

### DIFF
--- a/internal/explorer.point/src/components/LinkPointToSol.jsx
+++ b/internal/explorer.point/src/components/LinkPointToSol.jsx
@@ -1,0 +1,119 @@
+import { useState, useEffect } from 'react';
+import Swal from 'sweetalert2';
+import { useAppContext } from '../context/AppContext';
+
+const USER_REJECTION_CODE = 4001;
+const LS_KEY = 'point_to_sol_msg';
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const styles = {
+    container: {
+        borderRadius: 4,
+        boxShadow: '0px 7px 15px 0 rgba(0, 0, 0, .15)',
+        padding: 16,
+        marginTop: 24,
+        color: 'rgb(124, 124, 124)',
+        display: 'grid',
+        gridTemplateColumns: '1fr 200px',
+        alignItems: 'center',
+        gridColumnGap: 42,
+    },
+    description: {
+        margin: 0,
+    },
+};
+
+const LinkPointToSol = () => {
+    const { walletIdentity } = useAppContext();
+    const [hasPointAddress, setHasPointAddress] = useState(true);
+    const [display, setDisplay] = useState(
+        () => localStorage.getItem(LS_KEY) !== 'hide',
+    );
+
+    useEffect(() => {
+        async function fetchData() {
+            try {
+                const { data } = await window.point.identity.identityToOwner({
+                    identity: walletIdentity,
+                });
+                if (!data.pointAddress || data.pointAddress === EMPTY_ADDRESS) {
+                    setHasPointAddress(false);
+                }
+            } catch (err) {
+                console.error(err);
+            }
+        }
+
+        if (
+            walletIdentity.endsWith('.sol') &&
+            window.point.point.link_point_to_sol
+        ) {
+            fetchData();
+        }
+    }, [walletIdentity]);
+
+    const linkPointToSol = async () => {
+        try {
+            await window.point.point.link_point_to_sol(walletIdentity);
+            await Swal.fire(
+                'Done!',
+                'You have successfully linked your POINT address to your SOL domain.',
+                'success',
+            );
+            setDisplay(false);
+        } catch (err) {
+            if (err.code === USER_REJECTION_CODE) {
+                await Swal.fire('Request cancelled.', '', 'info');
+            } else {
+                await Swal.fire(
+                    'Sorry, something went wrong',
+                    'Please try again later or contact support',
+                    'error',
+                );
+                console.error(err);
+            }
+        }
+    };
+
+    const handleRemindMeLater = () => {
+        setDisplay(false);
+    };
+
+    const handleDoNotShowAgain = () => {
+        localStorage.setItem(LS_KEY, 'hide');
+        setDisplay(false);
+    };
+
+    if (hasPointAddress || !display) {
+        return null;
+    }
+
+    return (
+        <div style={styles.container}>
+            <p style={styles.description}>
+                We've noticed you're using a <em>SOL</em> domain, for the best
+                experience, we recommend linking your <em>POINT</em> address to
+                your <em>SOL</em> domain.
+            </p>
+            <button className="btn btn-md btn-success" onClick={linkPointToSol}>
+                Link POINT to SOL
+            </button>
+            <div>
+                <button
+                    className="btn btn-sm btn-link"
+                    onClick={handleRemindMeLater}
+                >
+                    Remind me later
+                </button>
+                <button
+                    className="btn btn-sm btn-link"
+                    onClick={handleDoNotShowAgain}
+                >
+                    Don't show this again
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default LinkPointToSol;

--- a/internal/explorer.point/src/components/LinkPointToSol.jsx
+++ b/internal/explorer.point/src/components/LinkPointToSol.jsx
@@ -8,18 +8,23 @@ const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const styles = {
     container: {
+        position: 'absolute',
+        top: 60,
+        left: 0,
+        right: 0,
+        backgroundColor: 'white',
         borderRadius: 4,
         boxShadow: '0px 7px 15px 0 rgba(0, 0, 0, .15)',
-        padding: 16,
-        marginTop: 24,
+        padding: '8px 24px',
         color: 'rgb(124, 124, 124)',
         display: 'grid',
-        gridTemplateColumns: '1fr 200px',
+        gridTemplateColumns: '1fr 100px',
         alignItems: 'center',
-        gridColumnGap: 42,
+        gridColumnGap: 24,
     },
     description: {
         margin: 0,
+        padding: 0,
     },
 };
 
@@ -30,7 +35,7 @@ const learnMoreHTMLString = (solDomain) => `
     </p>
     <p>
         For example, people will be able to email you at <b>${solDomain}</b>,
-        send POINT to it, share files, etc.
+        send POINTs to it, share files, etc.
     </p>
     <p>
         <em>
@@ -117,34 +122,36 @@ const LinkPointToSol = () => {
 
     return (
         <div style={styles.container}>
-            <p style={styles.description}>
-                We've noticed you're using a <em>SOL</em> domain, for the best
-                experience, we recommend linking your <em>POINT</em> address to
-                your <em>SOL</em> domain.
-            </p>
-            <button className="btn btn-md btn-success" onClick={linkPointToSol}>
-                Link POINT to SOL
-            </button>
             <div>
-                <button
-                    className="btn btn-sm btn-link"
-                    onClick={handleRemindMeLater}
-                >
-                    Remind me later
-                </button>
-                <button
-                    className="btn btn-sm btn-link"
-                    onClick={handleDoNotShowAgain}
-                >
-                    Don't show this again
-                </button>
-                <button
-                    className="btn btn-sm btn-link"
-                    onClick={handleLearnMore}
-                >
-                    Learn more
-                </button>
+                <p style={styles.description}>
+                    We've noticed you're using a <em>SOL</em> domain, for the
+                    best experience, we recommend linking your <em>POINT</em>{' '}
+                    address to it.
+                </p>
+                <div>
+                    <button
+                        className="btn btn-sm btn-link"
+                        onClick={handleRemindMeLater}
+                    >
+                        Remind me later
+                    </button>
+                    <button
+                        className="btn btn-sm btn-link"
+                        onClick={handleDoNotShowAgain}
+                    >
+                        Don't show this again
+                    </button>
+                    <button
+                        className="btn btn-sm btn-link"
+                        onClick={handleLearnMore}
+                    >
+                        Learn more
+                    </button>
+                </div>
             </div>
+            <button className="btn btn-md btn-success" onClick={linkPointToSol}>
+                Link
+            </button>
         </div>
     );
 };

--- a/internal/explorer.point/src/components/LinkPointToSol.jsx
+++ b/internal/explorer.point/src/components/LinkPointToSol.jsx
@@ -23,6 +23,25 @@ const styles = {
     },
 };
 
+const learnMoreHTMLString = (solDomain) => `
+    <p>
+        By linking your POINT address, you will be able to use your SOL domain
+        to interact in Point Network.
+    </p>
+    <p>
+        For example, people will be able to email you at <b>${solDomain}</b>,
+        send POINT to it, share files, etc.
+    </p>
+    <p>
+        <em>
+            <small>
+                Please mind that this requires writing to your Solana Domain Registry,
+                which means it will cost some SOL to cover the transaction fees.
+            </small>
+        </em>
+    </p>
+`;
+
 const LinkPointToSol = () => {
     const { walletIdentity } = useAppContext();
     const [hasPointAddress, setHasPointAddress] = useState(true);
@@ -84,6 +103,14 @@ const LinkPointToSol = () => {
         setDisplay(false);
     };
 
+    const handleLearnMore = async () => {
+        await Swal.fire(
+            'Linking your POINT address',
+            learnMoreHTMLString(walletIdentity),
+            'info',
+        );
+    };
+
     if (hasPointAddress || !display) {
         return null;
     }
@@ -110,6 +137,12 @@ const LinkPointToSol = () => {
                     onClick={handleDoNotShowAgain}
                 >
                     Don't show this again
+                </button>
+                <button
+                    className="btn btn-sm btn-link"
+                    onClick={handleLearnMore}
+                >
+                    Learn more
                 </button>
             </div>
         </div>

--- a/internal/explorer.point/src/components/LinkPointToSol.jsx
+++ b/internal/explorer.point/src/components/LinkPointToSol.jsx
@@ -46,7 +46,7 @@ const LinkPointToSol = () => {
 
         if (
             walletIdentity.endsWith('.sol') &&
-            window.point.point.link_point_to_sol
+            typeof window.point.point.link_point_to_sol === 'function'
         ) {
             fetchData();
         }

--- a/internal/explorer.point/src/pages/Home.jsx
+++ b/internal/explorer.point/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Container from 'react-bootstrap/Container';
 import Loading from '../components/Loading';
+import LinkPointToSol from '../components/LinkPointToSol';
 import appLogo from '../assets/pointlogo.png';
 import blogIcon from '../assets/blog.svg';
 import emailIcon from '../assets/email.svg';
@@ -135,6 +136,8 @@ export default function Home() {
 
     return (
         <Container className="home-container">
+            <LinkPointToSol />
+
             <h1 className="home-header">
                 Welcome to <span>Web 3.0</span>
             </h1>

--- a/src/api/api_routes.js
+++ b/src/api/api_routes.js
@@ -29,12 +29,6 @@ module.exports = [
         'IdentityController@isIdentityRegistered',
         {protected: true}
     ],
-    [
-        'POST',
-        '/v1/api/identity/linkPointAddress/',
-        'IdentityController@linkPointAddress',
-        {protected: true}
-    ],
     ['POST', '/v1/api/identity/blockTimestamp', 'IdentityController@blockTimestamp'], // TODO: why POST?
     ['POST', '/v1/api/identity/open', 'IdentityController@openLink', {protected: true}],
     ['POST', '/v1/api/identity/register', 'IdentityController@registerIdentity', {protected: true}],

--- a/src/api/api_routes.js
+++ b/src/api/api_routes.js
@@ -29,6 +29,12 @@ module.exports = [
         'IdentityController@isIdentityRegistered',
         {protected: true}
     ],
+    [
+        'POST',
+        '/v1/api/identity/linkPointAddress/',
+        'IdentityController@linkPointAddress',
+        {protected: true}
+    ],
     ['POST', '/v1/api/identity/blockTimestamp', 'IdentityController@blockTimestamp'], // TODO: why POST?
     ['POST', '/v1/api/identity/open', 'IdentityController@openLink', {protected: true}],
     ['POST', '/v1/api/identity/register', 'IdentityController@registerIdentity', {protected: true}],

--- a/src/api/controllers/IdentityController.js
+++ b/src/api/controllers/IdentityController.js
@@ -466,6 +466,26 @@ class IdentityController extends PointSDKController {
             this.rep.status(500).send('Internal server error');
         }
     }
+
+    async linkPointAddress() {
+        const {domain, network} = this.req.body;
+        if (network !== 'solana') {
+            const msg = `Sorry, ${network} is not supported, only solana is supported at the moment`;
+            const status = 400;
+            this.rep.status(status);
+            return this._status(status)._response({errorMsg: msg});
+        }
+
+        try {
+            const pointAddress = getNetworkAddress();
+            const txId = await solana.setPointAddress(domain, pointAddress);
+            return this._response({txId});
+        } catch (err) {
+            const status = 500;
+            this.rep.status(status);
+            return this._status(status)._response({errorMsg: err.message});
+        }
+    }
 }
 
 module.exports = IdentityController;

--- a/src/api/controllers/IdentityController.js
+++ b/src/api/controllers/IdentityController.js
@@ -152,7 +152,7 @@ class IdentityController extends PointSDKController {
         } else if (identity.endsWith('.eth')) {
             const registry = await ethereum.resolveDomain(identity);
             owner = registry.owner;
-            pointAddress = ''; // TODO: replicate SNS implementation in ENS.
+            pointAddress = registry.owner;
             network = 'ethereum';
         } else {
             const address = await ethereum.ownerByIdentity(identity);
@@ -464,26 +464,6 @@ class IdentityController extends PointSDKController {
             log.error('IKV Put error');
             log.error(e);
             this.rep.status(500).send('Internal server error');
-        }
-    }
-
-    async linkPointAddress() {
-        const {domain, network} = this.req.body;
-        if (network !== 'solana') {
-            const msg = `Sorry, ${network} is not supported, only solana is supported at the moment`;
-            const status = 400;
-            this.rep.status(status);
-            return this._status(status)._response({errorMsg: msg});
-        }
-
-        try {
-            const pointAddress = getNetworkAddress();
-            const txId = await solana.setPointAddress(domain, pointAddress);
-            return this._response({txId});
-        } catch (err) {
-            const status = 500;
-            this.rep.status(status);
-            return this._status(status)._response({errorMsg: err.message});
         }
     }
 }

--- a/src/name_service/registry.test.ts
+++ b/src/name_service/registry.test.ts
@@ -8,15 +8,29 @@ const owner = 'blockchain_address-not_important_for_these_tests';
 const testCases: TestCase[] = [
     [
         {owner, content: 'ipfs=cid'},
-        {identity: '', isAlias: false, rootDirId: '', routesId: ''}
+        {identity: '', isAlias: false, rootDirId: '', routesId: '', pointAddress: ''}
     ],
     [
         {owner, content: 'ipfs=cid;pn_alias=ynet_blog'},
-        {identity: 'ynet_blog', isAlias: true}
+        {identity: 'ynet_blog', isAlias: true, pointAddress: '', routesId: '', rootDirId: ''}
     ],
     [
         {owner, content: 'pn_alias=ynet_blog;arwv=chunkId'},
-        {identity: 'ynet_blog', isAlias: true}
+        {identity: 'ynet_blog', isAlias: true, pointAddress: '', routesId: '', rootDirId: ''}
+    ],
+    [
+        {
+            owner,
+            content:
+                'pn_alias=ynet_blog;arwv=chunkId;pn_addr=0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B'
+        },
+        {
+            identity: 'ynet_blog',
+            isAlias: true,
+            pointAddress: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B',
+            routesId: '',
+            rootDirId: ''
+        }
     ],
     [
         {
@@ -27,20 +41,36 @@ const testCases: TestCase[] = [
             identity: '',
             isAlias: false,
             routesId: 'routes-chunk-id',
-            rootDirId: 'root-chunk-id'
+            rootDirId: 'root-chunk-id',
+            pointAddress: ''
         }
     ],
     [
         {
             owner,
             content:
-                'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
+                'ipfs=QmPnNSjCPPNo4ckjaZ5BD82jSjxYJ7MBc5BVv2cWeYE6dn;pn_routes=0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d;pn_root=d7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd;pn_addr=0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B'
         },
         {
             identity: '',
             isAlias: false,
             routesId: '0x339b11f3cd1fc986d77356f2be50544a38b01fe64b744262e656813827e6555d',
-            rootDirId: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd'
+            rootDirId: 'd7817fbdda33796626b3f2cebe08b422168ac951378392d29ab239232a0cecdd',
+            pointAddress: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B'
+        }
+    ],
+    [
+        {
+            owner,
+            content:
+                'pn_addr=0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B;pn_root=root-id;pn_routes=routes-id'
+        },
+        {
+            identity: '',
+            isAlias: false,
+            routesId: 'routes-id',
+            rootDirId: 'root-id',
+            pointAddress: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B'
         }
     ]
 ];

--- a/src/name_service/registry.ts
+++ b/src/name_service/registry.ts
@@ -7,20 +7,11 @@ import {parseCookieString} from '../util';
  */
 export function parseDomainRegistry(registry: DomainRegistry): PointDomainData {
     const values = parseCookieString(registry.content ?? '');
-
-    // If the registry has a `pn_alias`, it means we need to redirect
-    // all requests to the `.sol` domain to the `.point` alias.
-    if (values['pn_alias']) {
-        return {identity: values['pn_alias'], isAlias: true};
-    }
-
-    // The registry does not have a `pn_alias`, which means we need to fetch
-    // the content using the routes ID and root directory ID stored in the
-    // domain registry.
     return {
-        identity: '',
-        isAlias: false,
-        routesId: values['pn_routes'] || '',
-        rootDirId: values['pn_root'] || ''
+        pointAddress: values.pn_addr || '',
+        identity: values.pn_alias || '',
+        isAlias: Boolean(values.pn_alias),
+        routesId: values.pn_alias ? '' : values.pn_routes || '',
+        rootDirId: values.pn_alias ? '' : values.pn_root || ''
     };
 }

--- a/src/name_service/types.ts
+++ b/src/name_service/types.ts
@@ -1,8 +1,9 @@
 export type PointDomainData = {
     identity: string;
     isAlias: boolean;
-    routesId?: string;
-    rootDirId?: string;
+    routesId: string;
+    rootDirId: string;
+    pointAddress: string;
 };
 
 export type DomainRegistry = {

--- a/src/network/providers/solana.ts
+++ b/src/network/providers/solana.ts
@@ -18,7 +18,7 @@ import {getSolanaKeyPair} from '../../wallet/keystore';
 import config from 'config';
 import axios from 'axios';
 import {DomainRegistry} from '../../name_service/types';
-import {encodeCookieString, merge} from '../../util/cookieString';
+import {encodeCookieString, mergeAndResolveConflicts} from '../../util/cookieString';
 const logger = require('../../core/log');
 const log = logger.child({module: 'SolanaProvider'});
 
@@ -373,7 +373,9 @@ const solana = {
         }
 
         // Write to Domain Registry and return Tx ID.
-        const data = encodeCookieString(merge(preExistingContent, {pn_addr: pointAddress}));
+        const data = encodeCookieString(
+            mergeAndResolveConflicts(preExistingContent, {pn_addr: pointAddress})
+        );
         const txId = await solana.setDomainContent(solDomain, data, network);
         log.info({solDomain, pointAddress, txId}, 'Wrote Point address to SOL record.');
         return txId;

--- a/src/network/providers/solana.ts
+++ b/src/network/providers/solana.ts
@@ -18,6 +18,7 @@ import {getSolanaKeyPair} from '../../wallet/keystore';
 import config from 'config';
 import axios from 'axios';
 import {DomainRegistry} from '../../name_service/types';
+import {encodeCookieString, merge} from '../../util/cookieString';
 const logger = require('../../core/log');
 const log = logger.child({module: 'SolanaProvider'});
 
@@ -347,6 +348,34 @@ const solana = {
         ixs.push(updateIx);
 
         const txId = await sendInstructions(connection, [wallet], ixs);
+        return txId;
+    },
+    setPointAddress: async (solDomain: string, pointAddress: string, network = 'solana') => {
+        // Check ownership of .sol domain
+        const id = Date.now();
+        const [{result}, domainRegistry] = await Promise.all([
+            solana.requestAccount(id, network),
+            solana.resolveDomain(solDomain, network)
+        ]);
+
+        const solanaAddress = result.publicKey;
+        if (solanaAddress !== domainRegistry.owner) {
+            const errMsg = `"${solDomain}" is owned by ${domainRegistry.owner}, you need to transfer it to your Point Wallet (${solanaAddress}). Also, please make sure you have some SOL in your Point Wallet to cover transaction fees.`;
+            log.error({solanaAddress, solDomain, domainOwner: domainRegistry.owner}, errMsg);
+            throw new Error(errMsg);
+        }
+
+        // Preserve any existing content, (over)writing the `pn_addr` key only.
+        let preExistingContent = '';
+        const {content} = domainRegistry;
+        if (content && typeof content === 'string' && content.trim()) {
+            preExistingContent = content;
+        }
+
+        // Write to Domain Registry and return Tx ID.
+        const data = encodeCookieString(merge(preExistingContent, {pn_addr: pointAddress}));
+        const txId = await solana.setDomainContent(solDomain, data, network);
+        log.info({solDomain, pointAddress, txId}, 'Wrote Point address to SOL record.');
         return txId;
     },
     isAddress: (address: string) => {

--- a/src/util/cookieString.test.ts
+++ b/src/util/cookieString.test.ts
@@ -1,4 +1,4 @@
-import {parseCookieString, encodeCookieString, merge} from './cookieString';
+import {parseCookieString, encodeCookieString, mergeAndResolveConflicts} from './cookieString';
 
 type ParseTestCase = [string, Record<string, string>];
 
@@ -102,6 +102,6 @@ const mergeTestCases: MergeTestCase[] = [
 
 describe('merge', () => {
     test.each(mergeTestCases)('merges %s and %s', (str, obj, expected) => {
-        expect(merge(str, obj)).toEqual(expected);
+        expect(mergeAndResolveConflicts(str, obj)).toEqual(expected);
     });
 });

--- a/src/util/cookieString.test.ts
+++ b/src/util/cookieString.test.ts
@@ -69,7 +69,35 @@ const mergeTestCases: MergeTestCase[] = [
         {a: 'b', pn_root: 'root-id', pn_routes: 'routes-id'}
     ],
     ['pn_root=root-id;pn_routes=routes-id', {pn_alias: 'social'}, {pn_alias: 'social'}],
-    ['pn_root=root-id;a=b;pn_routes=routes-id', {pn_alias: 'social'}, {a: 'b', pn_alias: 'social'}]
+    ['pn_root=root-id;a=b;pn_routes=routes-id', {pn_alias: 'social'}, {a: 'b', pn_alias: 'social'}],
+    [
+        'pn_root=root-id;pn_routes=routes-id',
+        {pn_addr: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B'},
+        {
+            pn_root: 'root-id',
+            pn_routes: 'routes-id',
+            pn_addr: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B'
+        }
+    ],
+    [
+        'pn_addr=0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B;pn_alias=aka',
+        {pn_addr: '0x5F13B25C1cA5d121aF55482679393064ad3C448D'},
+        {pn_addr: '0x5F13B25C1cA5d121aF55482679393064ad3C448D', pn_alias: 'aka'}
+    ],
+    [
+        'pn_addr=0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B;pn_root=root-id;pn_routes=routes-id',
+        {pn_alias: 'aka'},
+        {pn_addr: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B', pn_alias: 'aka'}
+    ],
+    [
+        'pn_addr=0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B;pn_root=root-id;pn_routes=routes-id',
+        {pn_root: 'new-root', pn_routes: 'new-routes'},
+        {
+            pn_addr: '0xF5277b8B7a620f1E04a4a205A6e552D084BBf76B',
+            pn_root: 'new-root',
+            pn_routes: 'new-routes'
+        }
+    ]
 ];
 
 describe('merge', () => {

--- a/src/util/cookieString.ts
+++ b/src/util/cookieString.ts
@@ -39,7 +39,10 @@ export function encodeCookieString(obj: Record<string, string>): string {
  * Merges a new object with an existing "cookie string",
  * making sure not to duplicate any keys.
  */
-export function merge(old: string, obj: Record<string, string>): Record<string, string> {
+export function mergeAndResolveConflicts(
+    old: string,
+    obj: Record<string, string>
+): Record<string, string> {
     const prevData = parseCookieString(old);
 
     // If there's a pn_alias, there cannot be pn_root + pn_routes (and viceversa)

--- a/src/util/cookieString.ts
+++ b/src/util/cookieString.ts
@@ -42,10 +42,13 @@ export function encodeCookieString(obj: Record<string, string>): string {
 export function merge(old: string, obj: Record<string, string>): Record<string, string> {
     const prevData = parseCookieString(old);
 
-    // Delete `point` keys to avoid inconsistencies like having a `pn_alias` together with a `pn_root`,
-    delete prevData.pn_root;
-    delete prevData.pn_routes;
-    delete prevData.pn_alias;
+    // If there's a pn_alias, there cannot be pn_root + pn_routes (and viceversa)
+    if (obj.pn_alias) {
+        delete prevData.pn_root;
+        delete prevData.pn_routes;
+    } else if (obj.pn_root) {
+        delete prevData.pn_alias;
+    }
 
     return {...prevData, ...obj};
 }

--- a/tests/api/identityController.spec.js
+++ b/tests/api/identityController.spec.js
@@ -66,7 +66,8 @@ describe('Identity controller', () => {
                 status: 200,
                 data: {
                     owner: '0xF6690149C78D0254EF65FDAA6B23EC6A342f6d8D',
-                    network: 'point'
+                    network: 'point',
+                    pointAddress: '0xF6690149C78D0254EF65FDAA6B23EC6A342f6d8D'
                 },
                 headers: {}
             })


### PR DESCRIPTION
Please refer to [the ticket](https://point-labs.atlassian.net/browse/PN-223) for context.


## READ

The `identityToOwner` response has a new `pointAddress` key.

- If the identity is _.point_, `pointAddress` will be the same as `owner`.
- if the identity is _.sol_, `pontAddress` will be the Point Address of the current user, and `owner` will be the Solana address that owns the .sol domain.
- if the identity is _.eth_, `pointAddress` will be the same as `owner`, and will refer to the Ethereum address that owns the .eth domain.

It was implemented like this to keep the `owner` key as it was, and avoid breaking changes.


## WRITE

The homepage of Point Explorer shows a recommendation to SOL domain owners to "link" their POINT address. In practice, this means writing the Point Address to the `POINT` record of the Solana Domain Registry.

If users accept the recommendation and click the "link" button, we use Point SDK to communicate with Point Engine and follow the regular flow, where the user is presented with a confirmation window to accept the transaction.

This is not mandatory, so users can ignore our recommendation and dismiss the message on Point Explorer's homepage.

For a quick demo, please check out [this video](https://drive.google.com/file/d/1xDcPzBUbEjGDeM90Q52LzauUyOp-fvjI/view?usp=sharing).