### PR TITLE
PN-226 Add Point Address to Identity page of SOL domains

### DIFF
--- a/internal/explorer.point/src/components/LinkPointToSol.jsx
+++ b/internal/explorer.point/src/components/LinkPointToSol.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import Swal from 'sweetalert2';
 import { useAppContext } from '../context/AppContext';
+import useLinkPointToSol from '../hooks/useLinkPointToSol';
 
-const USER_REJECTION_CODE = 4001;
 const LS_KEY = 'point_to_sol_msg';
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -53,6 +53,9 @@ const LinkPointToSol = () => {
     const [display, setDisplay] = useState(
         () => localStorage.getItem(LS_KEY) !== 'hide',
     );
+    const linkPointToSol = useLinkPointToSol(walletIdentity, () =>
+        setDisplay(false),
+    );
 
     useEffect(() => {
         async function fetchData() {
@@ -75,29 +78,6 @@ const LinkPointToSol = () => {
             fetchData();
         }
     }, [walletIdentity]);
-
-    const linkPointToSol = async () => {
-        try {
-            await window.point.point.link_point_to_sol(walletIdentity);
-            await Swal.fire(
-                'Done!',
-                'You have successfully linked your POINT address to your SOL domain.',
-                'success',
-            );
-            setDisplay(false);
-        } catch (err) {
-            if (err.code === USER_REJECTION_CODE) {
-                await Swal.fire('Request cancelled.', '', 'info');
-            } else {
-                await Swal.fire(
-                    'Sorry, something went wrong',
-                    'Please try again later or contact support',
-                    'error',
-                );
-                console.error(err);
-            }
-        }
-    };
 
     const handleRemindMeLater = () => {
         setDisplay(false);

--- a/internal/explorer.point/src/components/PointAddressRow.jsx
+++ b/internal/explorer.point/src/components/PointAddressRow.jsx
@@ -1,0 +1,46 @@
+import useLinkPointToSol from '../hooks/useLinkPointToSol';
+
+const PointAddressRow = ({ handle, pointAddress, isOwner }) => {
+    const linkPointToSol = useLinkPointToSol(handle);
+
+    // Not a .sol domain, don't render anything.
+    if (!handle.endsWith('.sol')) {
+        return null;
+    }
+
+    // There's an associated Point Address, render it.
+    if (pointAddress) {
+        return (
+            <tr>
+                <th>Point Address:</th>
+                <td>{pointAddress}</td>
+            </tr>
+        );
+    }
+
+    // No Point Address and user is not owner of the identity
+    // being displayed, don't render anything.
+    if (!isOwner) {
+        return null;
+    }
+
+    // No Point Address and user is owner of the identity,
+    // give option to link Point Address to .sol domain.
+    return (
+        <tr>
+            <th>Point Address:</th>
+            <td style={{ display: 'flex', alignItems: 'center' }}>
+                You don't have a POINT address linked to your SOL domain.
+                <button
+                    className="btn btn-sm btn-outline-success"
+                    onClick={linkPointToSol}
+                    style={{ marginLeft: 8 }}
+                >
+                    Link now
+                </button>
+            </td>
+        </tr>
+    );
+};
+
+export default PointAddressRow;

--- a/internal/explorer.point/src/hooks/useLinkPointToSol.js
+++ b/internal/explorer.point/src/hooks/useLinkPointToSol.js
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import Swal from 'sweetalert2';
+
+const USER_REJECTION_CODE = 4001;
+
+const successMessage = `
+    <p>You have successfully linked your POINT address to your SOL domain.</p>
+    <p>
+        <small>
+            Please mind that changes may take a few minutes to take effect.
+        </small>
+    </p>
+`;
+
+/**
+ * Makes the request to set the Point Address in the `POINT` record of a
+ * Solana domain and displays either a success or error message to the user.
+ */
+export default function useLinkPointToSol(identity, onSuccess = () => {}) {
+    const linkPointToSol = useCallback(async () => {
+        try {
+            await window.point.point.link_point_to_sol(identity);
+            await Swal.fire('Done!', successMessage, 'success');
+            onSuccess();
+        } catch (err) {
+            if (err.code === USER_REJECTION_CODE) {
+                await Swal.fire('Request cancelled.', '', 'info');
+            } else {
+                await Swal.fire(
+                    'Sorry, something went wrong',
+                    'Please try again later or contact support',
+                    'error',
+                );
+                console.error(err);
+            }
+        }
+    }, [identity]);
+
+    return linkPointToSol;
+}

--- a/internal/explorer.point/src/pages/Identity.jsx
+++ b/internal/explorer.point/src/pages/Identity.jsx
@@ -4,6 +4,7 @@ import BlockTime from '../components/BlockTime';
 import React, { useState, useEffect } from 'react';
 import Loading from '../components/Loading';
 import OwnerToIdentity from '../components/OwnerToIdenity';
+import PointAddressRow from '../components/PointAddressRow';
 import Swal from 'sweetalert2';
 import { useAppContext } from '../context/AppContext';
 
@@ -12,6 +13,9 @@ const isHash = (str) => {
     if (s.length !== 64) return false;
     return new RegExp('^[0-9a-fA-F]+$').test(s);
 };
+
+const getDomainSpace = (handle) =>
+    handle.endsWith('.sol') ? handle : `${handle}.point`;
 
 const IkvEntry = (props) => {
     const { handle, item, onUpdated, showEdit } = props;
@@ -140,6 +144,7 @@ export default function Identity() {
     const [addAddress, setAddAddress] = useState('');
     const [publicKey, setPublicKey] = useState('');
     const [isLoadingPublicKey, setIsLoadingPublicKey] = useState(true);
+    const [pointAddress, setPointAddress] = useState('');
     const {
         walletAddr,
         publicKey: walletPublicKey,
@@ -160,6 +165,7 @@ export default function Identity() {
             identity: handle,
         });
         setOwner(result.data.owner);
+        setPointAddress(result.data.pointAddress);
         setIsLoadingOwner(false);
         setIsOwner(
             result.data.owner.toLowerCase() === walletAddr.toLowerCase(),
@@ -411,15 +417,20 @@ export default function Identity() {
                         <th>Owner:</th>
                         <td>{isLoadingOwner ? <Loading /> : owner}</td>
                     </tr>
+                    <PointAddressRow
+                        handle={handle}
+                        pointAddress={pointAddress}
+                        isOwner={isOwner}
+                    />
                     <tr>
                         <th>Domain Space:</th>
                         <td>
                             <a
-                                href={'https://' + handle + '.point/'}
+                                href={`https://${getDomainSpace(handle)}`}
                                 target="_blank"
                                 rel="noreferrer"
                             >
-                                {handle}.point
+                                {getDomainSpace(handle)}
                             </a>
                         </td>
                     </tr>


### PR DESCRIPTION
These changes add a row to the table that is displayed in the Identity page. This additional row is only displayed when dealing with a `.sol` identity, since the `owner` of such identities is a Solana address and not a Point one.

This is what it looks like in four different scenarios.

Owner seeing their own identity, before linking their Point address:
![owner_no_point_addr](https://user-images.githubusercontent.com/101118664/191347060-e79b237e-12bd-4f7c-8732-2d24e2a5b875.png)

Owner seeing their own identity, after having linked their Point address:
![owner_point_addr](https://user-images.githubusercontent.com/101118664/191347126-51e56c31-188d-4c1f-955a-513f46a0cab7.png)

Visitor seeing a `.sol` identity that does not have a Point address linked to it:
![visitor_no_point_addr](https://user-images.githubusercontent.com/101118664/191347230-6eec3843-1793-4049-b56d-07a48f6a3dfe.png)

Visitor seeing a `.sol` identity that has a Point address linked to it:
![visitor_point_addr](https://user-images.githubusercontent.com/101118664/191347289-1eeaee65-02aa-48dc-b3dc-2166ac7a5811.png)
