### PR TITLE
PN-240 Improve display of public key for .sol identities

### DIFF
--- a/internal/explorer.point/src/components/PublicKeyRow.jsx
+++ b/internal/explorer.point/src/components/PublicKeyRow.jsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import Loading from './Loading';
+
+const PublicKeyRow = ({ handle, isOwner, walletPublicKey }) => {
+    const [loading, setLoading] = useState(false);
+    const [publicKey, setPublicKey] = useState('');
+
+    useEffect(() => {
+        async function fetchPublicKey() {
+            setLoading(true);
+            try {
+                const result = await window.point.identity.publicKeyByIdentity({
+                    identity: handle,
+                });
+                setPublicKey(result.data.publicKey);
+            } catch {
+                setPublicKey('');
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        if (isOwner && !handle.endsWith('.sol')) {
+            setPublicKey(walletPublicKey);
+        } else {
+            fetchPublicKey();
+        }
+    }, [isOwner]);
+
+    const renderPublicKey = () => {
+        if (!publicKey && !isOwner) {
+            return 'n/a';
+        }
+        if (!publicKey && isOwner) {
+            return 'It will be available after you link your Point Address to your SOL domain.';
+        }
+
+        const matches = publicKey.replace('0x', '').match(/.{1,8}/g);
+        return matches ? matches.join(' ') : publicKey;
+    };
+
+    return (
+        <tr>
+            <th>Communication Public Key:</th>
+            <td className="overflow-wrap: break-word;">
+                {loading ? <Loading /> : renderPublicKey()}
+            </td>
+        </tr>
+    );
+};
+
+export default PublicKeyRow;

--- a/internal/explorer.point/src/pages/Identity.jsx
+++ b/internal/explorer.point/src/pages/Identity.jsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import Loading from '../components/Loading';
 import OwnerToIdentity from '../components/OwnerToIdenity';
 import PointAddressRow from '../components/PointAddressRow';
+import PublicKeyRow from '../components/PublicKeyRow';
 import Swal from 'sweetalert2';
 import { useAppContext } from '../context/AppContext';
 
@@ -57,7 +58,12 @@ const IkvEntry = (props) => {
             await window.point.contract.send({
                 contract: 'Identity',
                 method: 'ikvPut',
-                params: [handle.toLowerCase(), item.key, newValue, newVersionParam],
+                params: [
+                    handle.toLowerCase(),
+                    item.key,
+                    newValue,
+                    newVersionParam,
+                ],
             });
             setAllowEdition(false);
             onUpdated();
@@ -127,11 +133,6 @@ const IkvEntry = (props) => {
     );
 };
 
-function parsePublicKey(key) {
-    const matches = key.replace('0x', '').match(/.{1,8}/g);
-    return matches ? matches.join(' ') : key;
-}
-
 export default function Identity() {
     const { handle } = useParams();
     const [ikvset, setIkvset] = useState([]);
@@ -142,8 +143,6 @@ export default function Identity() {
     const [isLoadingDeployers, setIsLoadingDeployers] = useState(true);
     const [isOwner, setIsOwner] = useState(false);
     const [addAddress, setAddAddress] = useState('');
-    const [publicKey, setPublicKey] = useState('');
-    const [isLoadingPublicKey, setIsLoadingPublicKey] = useState(true);
     const [pointAddress, setPointAddress] = useState('');
     const {
         walletAddr,
@@ -171,29 +170,6 @@ export default function Identity() {
             result.data.owner.toLowerCase() === walletAddr.toLowerCase(),
         );
     };
-
-    const fetchPublicKey = async () => {
-        if (isOwner) {
-            setPublicKey(walletPublicKey);
-            return;
-        }
-
-        setIsLoadingPublicKey(true);
-        try {
-            const result = await window.point.identity.publicKeyByIdentity({
-                identity: handle,
-            });
-            setPublicKey(result.data.publicKey);
-        } catch {
-            setPublicKey('n/a');
-        } finally {
-            setIsLoadingPublicKey(false);
-        }
-    };
-
-    useEffect(() => {
-        fetchPublicKey();
-    }, [isOwner]);
 
     const fetchIkv = async () => {
         setIsLoadingIkv(true);
@@ -422,6 +398,11 @@ export default function Identity() {
                         pointAddress={pointAddress}
                         isOwner={isOwner}
                     />
+                    <PublicKeyRow
+                        handle={handle}
+                        isOwner={isOwner}
+                        walletPublicKey={walletPublicKey}
+                    />
                     <tr>
                         <th>Domain Space:</th>
                         <td>
@@ -432,16 +413,6 @@ export default function Identity() {
                             >
                                 {getDomainSpace(handle)}
                             </a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Communication Public Key:</th>
-                        <td className="overflow-wrap: break-word;">
-                            {isLoadingPublicKey ? (
-                                <Loading />
-                            ) : (
-                                parsePublicKey(publicKey)
-                            )}
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Owner of a `.sol` domain that has not been linked yet:
![owner_not_linked](https://user-images.githubusercontent.com/101118664/191963933-8b7b8165-b00b-4ce7-b8c4-fc4c7b218876.png)

Owner of a `.sol` domain that has linked the Point Address:
![owner_linked](https://user-images.githubusercontent.com/101118664/191963998-a7a757cf-d0ad-4231-9fc0-aec4cfe147a2.png)

Visitor seeing a "linked" `.sol` identity:
![visitor_linked](https://user-images.githubusercontent.com/101118664/191964098-d7dab2c6-a8eb-4cb8-9e13-e90f0d24cd6d.png)

Visitor seeing a "not linked" `.sol` identity:
![visitor_not_linked](https://user-images.githubusercontent.com/101118664/191964156-099cb0e9-5127-4588-9ac4-c7ef4c75ab80.png)
