### PR TITLE
PN-239 Don't show subidentities for SOL domains

### DIFF
--- a/internal/explorer.point/src/pages/MyIdentities.jsx
+++ b/internal/explorer.point/src/pages/MyIdentities.jsx
@@ -35,7 +35,9 @@ export default function MyIdentities({ owner }) {
                 </tbody>
             </table>
 
-            <Subidentities owner={owner} />
+            {walletIdentity?.endsWith('.sol') ? null : (
+                <Subidentities owner={owner} />
+            )}
         </Container>
     );
 }


### PR DESCRIPTION
Since `.sol` identities cannot register subidentities, I think the best approach is to simply hide the **Sub-Identies** section of _myidentities_ page.