### PR TITLE
PN-158 Use HTML error template in proxy handler

### DIFF
--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -238,10 +238,19 @@ const getHttpRequestHandler = () => async (req: FastifyRequest, res: FastifyRepl
         }
     } catch (e) {
         const status = e.httpStatusCode || 500;
+        res.status(status);
         log.error({stack: e.stack, errorMessage: e.message}, 'Error from Renderer');
-        return res
-            .status(status)
-            .send('Error from Renderer: ' + JSON.stringify(e.message).replace(/^"+|"+$/g, ''));
+        const parsedErrMsg = JSON.stringify(e.message).replace(/^"+|"+$/g, '');
+
+        if (req.headers.accept?.includes('text/html')) {
+            res.header('Content-Type', 'text/html');
+            return templateManager.render(Template.ERROR, {
+                code: status,
+                message: parsedErrMsg
+            });
+        }
+
+        return res.send(`Error from Renderer: ${parsedErrMsg}`);
     }
 };
 

--- a/src/client/proxy/views/error.hbs
+++ b/src/client/proxy/views/error.hbs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <body style='background-color: #222233;'>


### PR DESCRIPTION
Turns out we already had a template to render errors, but it wasn't used. I have added it to the last `catch` in proxy's _common handler_, but only if the requester accepts _html_ as a response, just in case there's some other clients other than the browser hitting this endpoint (although I can't think of such scenario, I wanted to be cautious).

It respects the error code when rendering the error page, it doesn't return a 200 with the error page.

It looks like this:
![Screenshot from 2022-09-26 14-11-40](https://user-images.githubusercontent.com/101118664/192340529-23d48c9d-218a-46b6-8af2-6d2e73d15d10.png)

