### PR TITLE
Change content type detection way

### DIFF
--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -282,14 +282,18 @@ const tryFulfillZhtmlRequest = async (
         renderer = new Renderer({rootDirId: cfg.remoteRootDirId} as any);
     }
 
-    res.header('Content-Type', 'text/html');
-
     // TODO: sanitize
-    return await renderer.render(templateId, templateFileContents, host, {
+    const rendered = await renderer.render(templateId, templateFileContents, host, {
         ...routeParams,
         ...queryParams,
         ...((req.body as Record<string, unknown>) ?? {})
     });
+    const contentType = detectContentType(Buffer.from(rendered));
+    if (!(contentType.match('text/html'))) {
+        throw new Error(`Not a valid HTML: ${templateFilename}`);
+    }
+    res.header('Content-Type', contentType);
+    return rendered;
 };
 
 const tryFulfillStaticRequest = async (cfg: RequestFulfillmentConfig, urlPath: string) => {

--- a/src/client/proxy/handlers/common.ts
+++ b/src/client/proxy/handlers/common.ts
@@ -12,7 +12,7 @@ import logger from '../../../core/log';
 import blockchain from '../../../network/providers/ethereum';
 import {getContentTypeFromExt, matchRouteAndParams} from '../proxyUtils';
 // @ts-expect-error no types for package
-import {detectContentType} from 'detect-content-type';
+import detectContentType from 'detect-content-type';
 import config from 'config';
 import {Template, templateManager} from '../templateManager';
 import {getMirrorWeb2Page} from './mirror';
@@ -252,7 +252,7 @@ const tryFulfillZhtmlRequest = async (
     host: string
 ) => {
     const {req, res} = cfg;
-    const {queryParams, ext} = await parseRequestForProxy(req);
+    const {queryParams} = await parseRequestForProxy(req);
 
     // This is a ZHTML file
     let templateFileContents, templateId;
@@ -282,9 +282,7 @@ const tryFulfillZhtmlRequest = async (
         renderer = new Renderer({rootDirId: cfg.remoteRootDirId} as any);
     }
 
-    const contentTypeFromExt = getContentTypeFromExt(ext || '');
-    const contentType = contentTypeFromExt || 'text/html';
-    res.header('Content-Type', contentType);
+    res.header('Content-Type', 'text/html');
 
     // TODO: sanitize
     return await renderer.render(templateId, templateFileContents, host, {
@@ -324,7 +322,10 @@ const tryFulfillStaticRequest = async (cfg: RequestFulfillmentConfig, urlPath: s
         file = await getFile(fileId, null);
     }
 
-    const contentType = ext ? getContentTypeFromExt(ext) : detectContentType(file);
+    let contentType = detectContentType(file);
+    if (contentType.match('text/plain') && ext) {
+        contentType = getContentTypeFromExt(ext);
+    }
     res.header('Content-Type', contentType);
 
     return file;

--- a/src/client/proxy/proxyUtils.ts
+++ b/src/client/proxy/proxyUtils.ts
@@ -33,7 +33,7 @@ export const getContentTypeFromExt = (ext: string) => {
     if (ext === 'zhtml') {
         ext = 'html';
     }
-    return mimeTypes.lookup('.' + ext) ?? 'application/octet-stream';
+    return mimeTypes.lookup('.' + ext);
 };
 
 export const isDirectoryJson = (text: string) => {


### PR DESCRIPTION
The idea:
- In the static handler, we first detect content type, using the lib. If it's detected as `text/plain`, we look at the extension, to handle `css` and `js`. Previously, we were first relying on the extension, so the content-type could be spoofed by malicious website.
- In HTML handler I've removed detection by extension and always return `text/html` instead, as it doesn't make sense.
I've tested explorer, social, email, created blog and drive, everything is working.