### PR TITLE
PN-242 Let .sol owners create .point identity

### DIFF
--- a/internal/explorer.point/src/App.js
+++ b/internal/explorer.point/src/App.js
@@ -54,6 +54,7 @@ const Main = () => {
                                 path="/deploy_blog"
                                 element={<DeployBlog />}
                             />
+                            <Route path="/registration" element={<Final />} />
                         </Routes>
                     ) : (
                         renderWalletIdentityMissing()

--- a/internal/explorer.point/src/custom.css
+++ b/internal/explorer.point/src/custom.css
@@ -246,3 +246,13 @@ a.nav-link.active {
     background: linear-gradient(90deg, rgba(71,53,17,1) 0%, rgba(223,180,0,1) 35%, rgba(237,208,12,1) 100%);
     color: rgb(255, 255, 255);
 }
+
+.vertical-center {
+    vertical-align: middle;
+}
+
+.with-content-right {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/internal/explorer.point/src/pages/Identity.jsx
+++ b/internal/explorer.point/src/pages/Identity.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import Container from 'react-bootstrap/Container';
 import React, { useState, useEffect } from 'react';
 import Loading from '../components/Loading';
@@ -11,6 +11,7 @@ import getDomainSpace from '../utils/getDomainSpace';
 
 export default function Identity() {
     const { handle } = useParams();
+    const navigate = useNavigate();
     const [owner, setOwner] = useState();
     const [isLoadingOwner, setIsLoadingOwner] = useState(true);
     const [isOwner, setIsOwner] = useState(false);
@@ -48,8 +49,22 @@ export default function Identity() {
             <table className="table table-bordered table-primary table-striped table-hover table-responsive">
                 <tbody>
                     <tr>
-                        <th>Handle:</th>
-                        <td>@{handle}</td>
+                        <th className="vertical-center">Handle:</th>
+                        <td className="with-content-right">
+                            @{handle}
+                            {isOwner && handle.endsWith('.sol') ? (
+                                <button
+                                    onClick={() => navigate('/registration')}
+                                    className="btn btn-sm btn-link"
+                                    title={
+                                        'You can create a Point identity to use in Point Network ' +
+                                        'instead of your .sol domain'
+                                    }
+                                >
+                                    Register Point Identity
+                                </button>
+                            ) : null}
+                        </td>
                     </tr>
                     <tr>
                         <th>Owner:</th>


### PR DESCRIPTION
`.sol` owners will see a link-button next to their handle in their identity page that will redirect them to the "registration" page, where they can register a `.point` identity.

Once done, the `.point` identity will take precedence over the `.sol` one.

![Screenshot from 2022-09-27 14-57-47](https://user-images.githubusercontent.com/101118664/192604132-a0b630b2-3db1-4767-927b-d0e06efa5dd0.png)
