### PR TITLE
PN-257 Add gas estimate to Txs

### DIFF
--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -46,7 +46,9 @@ const CONTRACT_BUILD_DIR = path.resolve(
     config.get('network.contracts_path')
 );
 const IDENTITY_CONTRACT_ID = config.get(`network.web3.${DEFAULT_NETWORK}.identity_contract_id`);
-const IDENTITY_CONTRACT_ADDRESS = config.get(`network.web3.${DEFAULT_NETWORK}.identity_contract_address`);
+const IDENTITY_CONTRACT_ADDRESS = config.get(
+    `network.web3.${DEFAULT_NETWORK}.identity_contract_address`
+);
 
 function createWeb3Instance({protocol, network}) {
     // TODO: this is actual for unit tests. If we want to add e2e tests, we may want to
@@ -1258,9 +1260,10 @@ ethereum.getGasPrice = async (network = DEFAULT_NETWORK) => {
     return gasPrice;
 };
 
-ethereum.getContractFromAbi = abi => {
+ethereum.getContractFromAbi = (abi, address) => {
     const web3 = getWeb3();
-    return new web3.eth.Contract(abi);
+    const args = address ? [abi, address] : [abi];
+    return new web3.eth.Contract(...args);
 };
 
 ethereum.deployContract = async (contract, artifacts, contractName) => {

--- a/src/rpc/decode.ts
+++ b/src/rpc/decode.ts
@@ -1,4 +1,5 @@
 const abiDecoder = require('abi-decoder');
+import {BigNumber} from 'ethers';
 import ethereum from '../network/providers/ethereum';
 import logger from '../core/log';
 import {CacheFactory} from '../util';
@@ -11,14 +12,23 @@ type Param = {
     type: string;
 };
 
-type DecodedTxInput = {
+export type DecodedTxInput = {
     name: string;
     params: Param[];
+    gas: {
+        value: string;
+        currency: string;
+    };
+};
+
+type ContractData = {
+    abi: object;
+    address: string;
 };
 
 // Keep track of which ABIs have been added, to avoid duplicates, with a TTL.
 const expiration = 10 * 60 * 1_000; // 10 minutes.
-const abiTracker = new CacheFactory<string, number>(expiration);
+const abiTracker = new CacheFactory<string, ContractData>(expiration);
 
 /**
  * Decode Tx and return human-readable input data.
@@ -41,20 +51,28 @@ export async function decodeTxInputData(
         return null;
     }
 
+    let contractInstance;
     const cacheKey = `${target}:${contract}`;
     if (!abiTracker.has(cacheKey)) {
         try {
             const identity = new URL(target).host.replace(/.point$/, '');
-            const {_jsonInterface} = await ethereum.loadWebsiteContract(identity, contract);
-            abiDecoder.addABI(_jsonInterface);
-            abiTracker.add(cacheKey, 1);
+            contractInstance = await ethereum.loadWebsiteContract(identity, contract);
+            abiDecoder.addABI(contractInstance._jsonInterface);
+            abiTracker.add(cacheKey, {
+                abi: contractInstance._jsonInterface,
+                address: contractInstance.options.address
+            });
         } catch (err) {
             log.error({target, contract}, 'Error fetching contract ABI.');
             return null;
         }
+    } else {
+        const {abi, address} = abiTracker.get(cacheKey)!;
+        contractInstance = ethereum.getContractFromAbi(abi, address);
     }
 
-    const decoded = abiDecoder.decodeMethod(txInputData);
+    const decoded: Omit<DecodedTxInput, 'gas'> | undefined = abiDecoder.decodeMethod(txInputData);
+
     if (!decoded) {
         log.error(
             {target, contract, txInputData},
@@ -63,5 +81,24 @@ export async function decodeTxInputData(
         return null;
     }
 
-    return decoded as DecodedTxInput;
+    const gas = {value: '', currency: ''};
+    try {
+        const method = contractInstance.methods && contractInstance.methods[decoded.name];
+        if (!method || typeof method !== 'function') {
+            throw new Error(`Method ${decoded.name} not found in contract ABI.`);
+        }
+
+        const args = decoded.params.map(p => p.value);
+        const from = ethereum.getOwner();
+        const gasAmount = await method(...args).estimateGas({from});
+        const gasPrice = await ethereum.getGasPrice();
+        gas.value = BigNumber.from(gasAmount)
+            .mul(gasPrice)
+            .toString();
+        gas.currency = 'POINT';
+    } catch (err) {
+        log.warn(err, `Unable to estimate gas for target: ${target}, contract: ${contract}.`);
+    }
+
+    return {...decoded, gas};
 }

--- a/src/rpc/rpc-handlers.ts
+++ b/src/rpc/rpc-handlers.ts
@@ -3,7 +3,7 @@ import pendingTxs from '../permissions/PendingTxs';
 import ethereum from '../network/providers/ethereum';
 import config from 'config';
 import solana, {SolanaSendFundsParams, TransactionJSON} from '../network/providers/solana';
-import {decodeTxInputData} from './decode';
+import {decodeTxInputData, DecodedTxInput} from './decode';
 import {getNetworkPublicKey} from '../wallet/keystore';
 import logger from '../core/log';
 const log = logger.child({module: 'RPC'});
@@ -132,12 +132,16 @@ const snsWriteRequest: HandlerFunc = async data => {
     const txData = {domain: params[0].domain, publicKey: getNetworkPublicKey()};
     const reqId = pendingTxs.add([txData], network);
 
-    const decodedTxData = {
+    const decodedTxData: DecodedTxInput = {
         name: 'SetPOINTRecord',
         params: [
             {name: 'SOLDomain', value: txData.domain, type: 'string'},
             {name: 'POINTPublicKey', value: txData.publicKey, type: 'byte64'} // NB: actually it is hex
-        ]
+        ],
+        gas: {
+            currency: 'SOL',
+            value: '0.00005'
+        }
     };
 
     return {status: 200, result: {reqId, network, decodedTxData}};


### PR DESCRIPTION
These changes add a gas estimate to the _decoded tx input_ that is returned when a transaction is stored for confirmation. Point SDK can use the additional gas information to show it in the Confirmation Window.

To keep it flexible, a `gas.currency` field has been added. Generally speaking, I think it should always be POINT, but this is useful to show gas estimate of other ad-hoc transactions, like dealing with SNS.