### PR TITLE
PN-262 Add metadata to decoded tx input

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -69,4 +69,4 @@ name_services:
 payments:
   token_address: "0xbf9be54Df2001E6Bd044cED0E508d936A9d38b1D"
 rpc:
-  send_transaction_timeout_secs: 120
+  send_transaction_timeout_secs: 300

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -346,3 +346,12 @@ export const getFileIdByPath = async (dirId: string, filePath: string): Promise<
         return getFileIdByPath(nextFileOrDir.id, path.join(...segments.slice(1)));
     }
 };
+
+export const isFileCached = async (fileId: string): Promise<boolean> => {
+    const id = (fileId.startsWith('0x') ? fileId.replace('0x', '') : fileId).toLowerCase();
+    const filePath = path.join(FILES_DIR, `file_${id}`);
+    return fs
+        .access(filePath)
+        .then(() => true)
+        .catch(() => false);
+};

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -1375,4 +1375,10 @@ ethereum.setDomainContent = async (domainName, data, network = 'rinkeby') => {
 
 ethereum.isAddress = address => ethers.utils.isAddress(address);
 
+ethereum.getTransactionReceipt = async (txHash, network = DEFAULT_NETWORK) => {
+    const provider = getEthers(network);
+    const receipt = await provider.getTransactionReceipt(txHash);
+    return receipt;
+};
+
 module.exports = ethereum;

--- a/src/rpc/rpc-handlers.ts
+++ b/src/rpc/rpc-handlers.ts
@@ -3,7 +3,7 @@ import pendingTxs from '../permissions/PendingTxs';
 import ethereum from '../network/providers/ethereum';
 import config from 'config';
 import solana, {SolanaSendFundsParams, TransactionJSON} from '../network/providers/solana';
-import {decodeTxInputData, DecodedTxInput} from './decode';
+import {decodeTxInputData, DecodedTxInput, addMetadata} from './decode';
 import {getNetworkPublicKey} from '../wallet/keystore';
 import logger from '../core/log';
 const log = logger.child({module: 'RPC'});
@@ -43,6 +43,9 @@ const storeTransaction: HandlerFunc = async data => {
     }
 
     const decodedTxData = await decodeTxInputData(target, contract, params);
+    if (decodedTxData) {
+        await addMetadata(decodedTxData, network);
+    }
 
     // Store request for future processing,
     // and send `reqId` to client so it can ask user approval.


### PR DESCRIPTION
These changes add some metadata to the transaction inputs, which is attached to the response that Point Engine sends when a transaction is stored for user confirmation.

The caller,  Point SDK, can use this additional metadata to enrich the information presented to the user in the confirmation window.

The metadata these changes add is related to inputs that look like storage IDs and empty hashes (_0x000..._).

- For an empty hash, it will simply return a "no_content" message.
- If the hash refers to a file on disk, a message indicating that it's a storage ID is returned.
- If the hash refers to a blockchain transaction hash for which a receipt can be fetched successfully, a message indicating it's a tx hash is returned.
- If the two checks above fail, a "not found" message is returned.