### PR TITLE
PN-265 Add identity metadata to transactions

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -154,7 +154,8 @@ export const sendToken = async ({tokenAddress, to, network = DEFAULT_NETWORK, va
         from: getWalletAddress({network}),
         to: tokenAddress,
         data,
-        value
+        value,
+        beneficiary: to
     }];
 
     const reqId = pendingTxs.add(params, network);


### PR DESCRIPTION
This PR implements two changes related to identities:

1. If one of the inputs of a transaction is an address, Point Engine will try to resolve it to an identity and it will attach some additional metadata to the response, so that Point SDK can present it in the confirmation window.
2. If the transaction is a token transfer, Point Engine will return the beneficiary address to Point SDK, so that it can present this information to the user in the confirmation window.

