### PR TITLE
Running npm run build instead of npx hardhat compile.

### DIFF
--- a/scripts/create-local-env.sh
+++ b/scripts/create-local-env.sh
@@ -57,8 +57,8 @@ rm -rf typechain
 rm -rf build
 echo "npm install --target_platform=$PLATFORM"
 npm install --target_platform=$PLATFORM
-echo "npx hardhat compile"
-npx hardhat compile
+echo "npm run build"
+npm run build
 cd ../pointnetwork
 npm install --target_platform=$PLATFORM
 

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -17,7 +17,7 @@ cd ../point-contracts
 rm -rf cache
 rm -rf typechain
 rm -rf build
-npx hardhat compile
+npm run build
 export MODE=zappdev
 npm start
 cp resources/Identity-address.json ../pointnetwork/hardhat/resources/ 


### PR DESCRIPTION
Running the bash alias `point-dev-install` was running `npx harhdat compile` in `point-contracts`, instead of `npm run build`. Currently, `npm run build` includes a workaround to an error we were getting related to not generating `typechain` directory in `point-contracts`.