### PR TITLE
PN-256 Change Solana RPC provider

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -56,7 +56,7 @@ network:
     solana:
       type: "solana"
       name: "Solana"
-      http_address: "api.mainnet-beta.solana.com"
+      http_address: "solana-api.projectserum.com"
       currency_name: "Sol"
       currency_code: "SOL"
       tls: true

--- a/config/devlocal.yaml
+++ b/config/devlocal.yaml
@@ -30,7 +30,7 @@ network:
     solana:
       type: "solana"
       name: "Solana"
-      http_address: "api.mainnet-beta.solana.com"
+      http_address: "solana-api.projectserum.com"
       currency_name: "Sol"
       currency_code: "SOL"
       tls: true

--- a/config/gateway.yaml
+++ b/config/gateway.yaml
@@ -52,7 +52,7 @@ network:
     solana:
       type: "solana"
       name: "Solana"
-      http_address: "api.mainnet-beta.solana.com"
+      http_address: "solana-api.projectserum.com"
       currency_name: "Sol"
       currency_code: "SOL"
       tls: true

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -53,7 +53,7 @@ network:
     solana:
       type: "solana"
       name: "Solana"
-      http_address: "api.mainnet-beta.solana.com"
+      http_address: "solana-api.projectserum.com"
       currency_name: "Sol"
       currency_code: "SOL"
       tls: true

--- a/config/visitlocal.yaml
+++ b/config/visitlocal.yaml
@@ -30,7 +30,7 @@ network:
     solana:
       type: "solana"
       name: "Solana"
-      http_address: "api.mainnet-beta.solana.com"
+      http_address: "solana-api.projectserum.com"
       currency_name: "Sol"
       currency_code: "SOL"
       tls: true


### PR DESCRIPTION
Please refer to [the ticket](https://point-labs.atlassian.net/browse/PN-256) for more details. In summary, public RPC providers such as `api.mainnet-beta.solana.com` have very restrictive limits as they are not meant for production use. The reserve the right of changing the limits and even block clients without prior notice.

They apply limits per RPC method, which would explain why some calls succeeded while other failed.

A quick workaround is to change to another provider, which is exactly what this PR is doing. Long term, we might want to consider private providers.