### PR TITLE
PN-269 Add feature flags to toggle name services on/off

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -66,6 +66,11 @@ network:
   event_block_page_size: 10000
 name_services:
   sol_tld_authority: "58PwtjSDuFHuUkYjH9BYnnQKHfwo9reZhC2zMJv9JPkx"
+  ens:
+    enabled: false
+  sns:
+    enabled: true
+    get_all_domains: true
 payments:
   token_address: "0xbf9be54Df2001E6Bd044cED0E508d936A9d38b1D"
 rpc:

--- a/src/network/providers/ethereum.js
+++ b/src/network/providers/ethereum.js
@@ -49,6 +49,7 @@ const IDENTITY_CONTRACT_ID = config.get(`network.web3.${DEFAULT_NETWORK}.identit
 const IDENTITY_CONTRACT_ADDRESS = config.get(
     `network.web3.${DEFAULT_NETWORK}.identity_contract_address`
 );
+const ENS_ENABLED = config.get('name_services.ens.enabled');
 
 function createWeb3Instance({protocol, network}) {
     // TODO: this is actual for unit tests. If we want to add e2e tests, we may want to
@@ -1313,6 +1314,11 @@ ethereum.send = ({method, params = [], id, network}) =>
  * (implements a cache to avoid querying Ethereum too often)
  */
 ethereum.resolveDomain = async (domainName, network = 'rinkeby') => {
+    if (!ENS_ENABLED) {
+        log.trace({ENS_ENABLED}, 'ENS has been disabled in config');
+        return {owner: '', content: null};
+    }
+
     const cacheKey = `${network}:${domainName}`;
     const cachedDomainRegistry = ensDomainCache.get(cacheKey);
     if (cachedDomainRegistry) {
@@ -1343,6 +1349,11 @@ ethereum.resolveDomain = async (domainName, network = 'rinkeby') => {
  * they are not automatically set up.
  */
 ethereum.getDomain = async (address, network = 'rinkeby') => {
+    if (!ENS_ENABLED) {
+        log.trace({ENS_ENABLED}, 'ENS has been disabled in config');
+        return null;
+    }
+
     const provider = getEthers(network);
     const domain = await provider.lookupAddress(address);
     const msg = domain ? 'Domain found.' : 'Domain not found.';
@@ -1351,6 +1362,11 @@ ethereum.getDomain = async (address, network = 'rinkeby') => {
 };
 
 ethereum.setDomainContent = async (domainName, data, network = 'rinkeby') => {
+    if (!ENS_ENABLED) {
+        log.trace({ENS_ENABLED}, 'ENS has been disabled in config');
+        return '';
+    }
+
     if (!networks[network] || !networks[network].eth_tld_resolver) {
         throw new Error(`Missing TLD public resolver contract address for network "${network}"`);
     }

--- a/src/network/providers/solana.ts
+++ b/src/network/providers/solana.ts
@@ -26,6 +26,9 @@ const log = logger.child({module: 'SolanaProvider'});
 // Address of the `.sol` TLD
 const SOL_TLD_AUTHORITY = new web3.PublicKey(config.get('name_services.sol_tld_authority'));
 
+const SNS_ENABLED = config.get('name_services.sns.enabled');
+const SNS_GET_ALL_DOMAINS = config.get('name_services.sns.get_all_domains');
+
 const cacheExpiration = 2 * 60 * 1_000; // 2 minutes
 const solDomainCache = new CacheFactory<string, DomainRegistry>(cacheExpiration);
 
@@ -76,9 +79,10 @@ const providers: Record<string, {connection: web3.Connection; wallet: web3.Keypa
         (acc, cur) => ({
             ...acc,
             [cur]: {
-                connection: config.get('mode') === 'test'
-                    ? null
-                    : createSolanaConnection(networks[cur].http_address),
+                connection:
+                    config.get('mode') === 'test'
+                        ? null
+                        : createSolanaConnection(networks[cur].http_address),
                 wallet: getSolanaKeyPair()
             }
         }),
@@ -252,6 +256,11 @@ const solana = {
      * (implements a cache to avoid querying Solana too often)
      */
     resolveDomain: async (domainName: string, network = 'solana'): Promise<DomainRegistry> => {
+        if (!SNS_ENABLED) {
+            log.trace({SNS_ENABLED}, 'SNS has been disabled in config');
+            return {owner: '', content: null};
+        }
+
         const provider = providers[network];
         if (!provider) {
             throw new Error(`Unknown network "${network}".`);
@@ -288,6 +297,11 @@ const solana = {
      * Otherwise, all domains owned by `owner` are retrieved and the first one is returned.
      */
     getDomain: async (owner: web3.PublicKey, network = 'solana'): Promise<string | null> => {
+        if (!SNS_ENABLED) {
+            log.trace({SNS_ENABLED}, 'SNS has been disabled in config');
+            return null;
+        }
+
         const provider = providers[network];
         if (!provider) {
             throw new Error(`Unknown network "${network}".`);
@@ -299,24 +313,28 @@ const solana = {
             log.debug({owner: owner.toBase58(), domain: reverse}, 'Favourite domain found.');
             return `${reverse}.sol`;
         } catch (err) {
-            // There's no favourite domain, retrieve them all and pick the first one.
-            // TODO: if there is more than 1 domain, ask the user to pick one.
-            try {
-                const domains = await getAllDomains(provider.connection, owner);
-                if (domains.length > 0) {
-                    const domainName = await performReverseLookup(provider.connection, domains[0]);
-                    log.debug(
-                        {
-                            owner: owner.toBase58(),
-                            numDomains: domains.length,
-                            firstDomain: domainName
-                        },
-                        'Domains found.'
-                    );
-                    return `${domainName}.sol`;
+            if (SNS_GET_ALL_DOMAINS) {
+                // There's no favourite domain, retrieve them all and pick the first one.
+                try {
+                    const domains = await getAllDomains(provider.connection, owner);
+                    if (domains.length > 0) {
+                        const domainName = await performReverseLookup(
+                            provider.connection,
+                            domains[0]
+                        );
+                        log.debug(
+                            {
+                                owner: owner.toBase58(),
+                                numDomains: domains.length,
+                                firstDomain: domainName
+                            },
+                            'Domains found.'
+                        );
+                        return `${domainName}.sol`;
+                    }
+                } catch (err) {
+                    log.debug(err, `Error trying to get all domains of ${owner}`);
                 }
-            } catch (err) {
-                log.debug(err, `Error trying to get all domains of ${owner}`);
             }
 
             log.debug({owner: owner.toBase58()}, 'No domains found.');
@@ -324,6 +342,11 @@ const solana = {
         }
     },
     setDomainContent: async (domainName: string, data: string, network = 'solana') => {
+        if (!SNS_ENABLED) {
+            log.trace({SNS_ENABLED}, 'SNS has been disabled in config');
+            return '';
+        }
+
         const provider = providers[network];
         if (!provider) {
             throw new Error(`Unknown network "${network}".`);
@@ -388,6 +411,11 @@ const solana = {
         return txId;
     },
     setPointReference: async (solDomain: string, network = 'solana') => {
+        if (!SNS_ENABLED) {
+            log.trace({SNS_ENABLED}, 'SNS has been disabled in config');
+            return '';
+        }
+
         // Check ownership of .sol domain
         const id = Date.now();
         const [{result}, domainRegistry] = await Promise.all([


### PR DESCRIPTION
In general, the idea is to be able to disable and enable _problematic/fragile_ functionality from a single place.

In particular, these changes add a few configuration variables to toggle name services on or off. Name services are particularly fragile because they depend on providers for Ethereum and Solana and we are not using providers with strong SLAs. Therefore, I think it makes sense to wrap this functionality in feature flags.

For **ENS**, I'm disabling it as it will not work until we migrate away from Rinkeby.

For **SNS**, I'm leaving it enabled because with the change in RPC provider ([this PR](https://github.com/pointnetwork/pointnetwork/pull/733)), it works. Also, for SNS, we have two flags, one to control the entire feature, and another one to control just the `getAllDomains` piece of the feature.