### PR TITLE
PN-272 Add endpoint to get list of events by dApp

### DIFF
--- a/src/api/api_routes.js
+++ b/src/api/api_routes.js
@@ -64,7 +64,12 @@ module.exports = [
     ['GET', '/v1/api/status/ping', 'PingController@ping'],
     ['GET', '/v1/api/status/meta', 'StatusController@meta'],
     ['POST', '/v1/api/deploy', 'DeployController@deploy', {gatewayDisabled: true}], // TODO: not protecting for now, but should
-    ['GET', '/v1/api/migrate', 'MigrateController@migrate', {protected: true, gatewayDisabled: true}],
+    [
+        'GET',
+        '/v1/api/migrate',
+        'MigrateController@migrate',
+        {protected: true, gatewayDisabled: true}
+    ],
     ['GET', '/v1/api/storage/files/:id', 'StorageController@fileById', {protected: true}],
     ['GET', '/v1/api/storage/getString/:id', 'StorageController@getString', {protected: true}],
     [
@@ -136,5 +141,6 @@ module.exports = [
     ],
     ['GET', '/v1/api/blockchain/networks', 'BlockchainController@networks', {protected: true}],
     ['POST', '/v1/api/contract/encodeFunctionCall', 'ContractController@encodeFunctionCall'],
-    ['POST', '/v1/api/contract/decodeParameters', 'ContractController@decodeParameters']
+    ['POST', '/v1/api/contract/decodeParameters', 'ContractController@decodeParameters'],
+    ['GET', '/v1/api/contract/listEvents/:identity', 'ContractController@listEvents']
 ];

--- a/src/api/controllers/ContractController.js
+++ b/src/api/controllers/ContractController.js
@@ -3,6 +3,7 @@ const config = require('config');
 const PointSDKController = require('./PointSDKController');
 const _ = require('lodash');
 const ethereum = require('../../network/providers/ethereum');
+const {getJSON} = require('../../client/storage');
 
 class ContractController extends PointSDKController {
     constructor(req, reply) {
@@ -160,6 +161,36 @@ class ContractController extends PointSDKController {
 
         const web3 = new Web3();
         return this._response(web3.eth.abi.decodeParameters(typesArray, hexString));
+    }
+
+    async listEvents() {
+        try {
+            const host = this.req.params.identity;
+            const identityContract = await ethereum.loadIdentityContract();
+            const data = await identityContract.methods.getIkvList(host).call();
+
+            if (!data || !Array.isArray(data) || data.length === 0) {
+                return this._response([]);
+            }
+
+            const contractEvents = [];
+            for (const ikvEntry of data) {
+                if (ikvEntry.length > 2 && ikvEntry[1].startsWith('zweb/contracts/abi')) {
+                    const abiStorageId = ikvEntry[2];
+                    const jsonInterface = await getJSON(abiStorageId);
+                    const {contractName, abi} = jsonInterface;
+                    const events = abi.filter(i => i.type === 'event').map(e => e.name);
+                    if (events.length > 0) {
+                        contractEvents.push({contractName, events});
+                    }
+                }
+            }
+
+            return this._response(contractEvents);
+        } catch (err) {
+            this.reply.status(500);
+            this._status(500)._response(err ?? 'Unable to find contract events');
+        }
     }
 }
 


### PR DESCRIPTION
The new endpoint `/v1/api/contract/listEvents/:identity` allows us to get a list of smart contract events implemented by a dApp.

If the dApp has deployed several contracts, we look for events in all of them, keeping a reference of which contract the events belong to.

If the dApp has not deployed any contracts, it will simply return an empty array.

For example:
```
GET /v1/api/contract/listEvents/social

    "data": [
        {
            "contractName": "PointSocial",
            "events": [
                "AdminChanged",
                "BeaconUpgraded",
                "OwnershipTransferred",
                "ProfileChange",
                "StateChange",
                "Upgraded"
            ]
        }
    ]
```