### PR TITLE
Request confirmation for keplr's sendTx

### DIFF
--- a/src/network/providers/keplr.ts
+++ b/src/network/providers/keplr.ts
@@ -17,3 +17,22 @@ export const keplr = new Keplr(
     'extension',
     requester
 );
+
+export const send = async (data: {
+    method: string;
+    network: string;
+    params?: unknown[];
+    id?: number;
+}) => {
+    const {method, params} = data;
+    const methodName = method.split('_')[1];
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const keplrMethod = keplr[methodName as keyof Keplr] as Function;
+    if (typeof keplrMethod !== 'function') {
+        throw new Error('Not valid method');
+    }
+
+    const result = (await keplrMethod.apply(keplr, params)) || {};
+    return result;
+};


### PR DESCRIPTION
These changes introduce the basic flow to _intercept_ some calls to the Keplr client and trigger the confirmation window flow.

I have also made a small refactor so that the implementation is a bit more aligned with Ethereum's and Solana's.
It's just a suggestion because the Keplr integration (or maybe I should say the Cosmos integration) is different, so it's not clear to me if it makes sense to try to align to Ethereum and Solana. For example, if a lot of methods are going to require user confirmation and payloads are too different, this approach could be more verbose. But for now, I think it helps.