### PR TITLE
PN-287 add point to keplr chains

### DIFF
--- a/src/network/config.ts
+++ b/src/network/config.ts
@@ -106,7 +106,11 @@ import {
     EVMOS_RPC_ENDPOINT,
     EVMOS_RPC_CONFIG,
     EVMOS_REST_ENDPOINT,
-    EVMOS_REST_CONFIG
+    EVMOS_REST_CONFIG,
+    POINT_RPC_ENDPOINT,
+    POINT_RPC_CONFIG,
+    POINT_REST_ENDPOINT,
+    POINT_REST_CONFIG
 } from './config.var';
 
 export const EmbedChainInfos: ChainInfo[] = [
@@ -1995,6 +1999,59 @@ export const EmbedChainInfos: ChainInfo[] = [
         ],
         features: ['ibc-transfer', 'ibc-go', 'eth-address-gen', 'eth-key-sign'],
         beta: true
+    },
+    {
+        rpc: POINT_RPC_ENDPOINT,
+        rpcConfig: POINT_RPC_CONFIG,
+        rest: POINT_REST_ENDPOINT,
+        restConfig: POINT_REST_CONFIG,
+        chainId: 'point_10687-1',
+        chainName: 'Point',
+        stakeCurrency: {
+            coinDenom: 'POINT',
+            coinMinimalDenom: 'apoint',
+            coinDecimals: 18,
+            coinGeckoId: 'point-network'
+        },
+        walletUrl:
+      process.env.NODE_ENV === 'production'
+          ? 'https://wallet.keplr.app/chains/point'
+          : 'http://localhost:8080/chains/point',
+        walletUrlForStaking:
+      process.env.NODE_ENV === 'production'
+          ? 'https://wallet.keplr.app/chains/point'
+          : 'http://localhost:8080/chains/point',
+        bip44: {coinType: 60},
+        bech32Config: {
+            bech32PrefixAccAddr: "point",
+            bech32PrefixAccPub: "pointpub",
+            bech32PrefixValAddr: "pointvaloper",
+            bech32PrefixValPub: "pointvaloperpub",
+            bech32PrefixConsAddr: "pointvalcons",
+            bech32PrefixConsPub: "pointvalconspub"
+        },
+        currencies: [
+            {
+                coinDenom: 'POINT',
+                coinMinimalDenom: 'apoint',
+                coinDecimals: 18,
+                coinGeckoId: 'point-network'
+            }
+        ],
+        feeCurrencies: [
+            {
+                coinDenom: 'POINT',
+                coinMinimalDenom: 'apoint',
+                coinDecimals: 18,
+                coinGeckoId: 'point-network',
+                gasPriceStep: {
+                    low: 5000000000,
+                    average: 25000000000,
+                    high: 40000000000
+                }
+            }
+        ],
+        features: ['ibc-transfer', 'ibc-go', 'eth-address-gen', 'eth-key-sign']
     }
 ];
 

--- a/src/network/config.var.ts
+++ b/src/network/config.var.ts
@@ -153,4 +153,9 @@ export const EVMOS_RPC_CONFIG: AxiosRequestConfig | undefined = undefined;
 export const EVMOS_REST_ENDPOINT = '';
 export const EVMOS_REST_CONFIG: AxiosRequestConfig | undefined = undefined;
 
+export const POINT_RPC_ENDPOINT = 'https://rpc-mainnet-1.point.space:26657';
+export const POINT_RPC_CONFIG: AxiosRequestConfig | undefined = undefined;
+export const POINT_REST_ENDPOINT = 'https://rpc-mainnet-1.point.space:1317';
+export const POINT_REST_CONFIG: AxiosRequestConfig | undefined = undefined;
+
 export const PRIVILEGED_ORIGINS: string[] = [];

--- a/src/rpc/rpc-handlers.ts
+++ b/src/rpc/rpc-handlers.ts
@@ -184,8 +184,10 @@ const specialHandlers: Record<string, HandlerFunc> = {
         }
     },
     // Keplr
-    keplr_sendTx: storeTransaction,
-    keplr_confirmTx: confirmTransaction
+    keplr_signAmino: async data => {
+        console.log(data);
+        return {status: 200, result: {msg: 'WIP'}};
+    }
 };
 
 // Handlers for methods related to permissions.
@@ -275,7 +277,9 @@ const handleRPC: HandlerFunc = async data => {
             case 'solana':
                 result = await solana.send({method, params, id, network});
                 break;
+            case 'cosmos':
             case 'keplr':
+                console.log({method, params});
                 result = await keplrSend({method, params, id, network});
                 break;
             default:


### PR DESCRIPTION
Adding Point Network to the chains known by Keplr so that we can `enable` it from the client and use it.

Having Point Network as one of Keplr's chains, its `chainId` can be used in the client to interact with it. In the image below, I am enabling it, getting an offline signer, getting the account, and signing an empty object:

![console](https://user-images.githubusercontent.com/101118664/199570991-b2469364-737e-4797-887f-d65f1f33f629.png)

You may notice that the return value of the `signer.sign()` call in the screenshot above is `{ msg: "WIP" }`. That's hardcoded on the Engine side. In the final implementation, that response should actually trigger the confirmation window, but for now it's just logging the data and returning a dummy response, so that we can inspect it.


This is the message that the Engine gets when `signer.sign()` is called:
![sign_message](https://user-images.githubusercontent.com/101118664/199571319-5bd0393e-5cfb-4564-b6ca-0d8aab65c098.png)
